### PR TITLE
fix ext Object

### DIFF
--- a/sentryext/ext.go
+++ b/sentryext/ext.go
@@ -39,7 +39,7 @@ func (d *SentryExt) Close() error {
 
 // Object implements Extension interface
 func (d *SentryExt) Object() interface{} {
-	return nil
+	return d
 }
 
 // Application implements Extension interface

--- a/seqgenext/ext.go
+++ b/seqgenext/ext.go
@@ -59,7 +59,7 @@ func (d *SequenceGeneratorExt) Init(app *gobay.Application) error {
 
 // Object implements Extension interface
 func (d *SequenceGeneratorExt) Object() interface{} {
-	return nil
+	return d
 }
 
 // Application implements Extension interface


### PR DESCRIPTION
没有办法直接从app.Get取出的Extension转成ext对应的struct，需要interface转一次。应该用Object方法来完成这个事情。