### PR TITLE
fix get ext lock

### DIFF
--- a/app.go
+++ b/app.go
@@ -38,9 +38,6 @@ func (d *Application) Get(key Key) Extension {
 
 // GetOK the extension at the specified key, return false when the component doesn't exist
 func (d *Application) GetOK(key Key) (Extension, bool) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
 	ext, ok := d.extensions[key]
 	if !ok {
 		return nil, ok


### PR DESCRIPTION
1. 只是Get，没有加锁的必要
2. 影响了初始化阶段，一个ext引用另一个ext。因为app.Init时已经加锁，这时想要取一个ext就会卡住。