### PR TITLE
调整CachedFunc的用法

### DIFF
--- a/cachext/ext.go
+++ b/cachext/ext.go
@@ -10,14 +10,17 @@ import (
 	"time"
 )
 
+type void struct{}
+
 // CacheExt
 type CacheExt struct {
-	NS          string
-	app         *gobay.Application
-	backend     CacheBackend
-	prefix      string
-	mu          sync.Mutex
-	initialized bool
+	NS             string
+	app            *gobay.Application
+	backend        CacheBackend
+	prefix         string
+	mu             sync.Mutex
+	initialized    bool
+	cachedFuncName map[string]void
 }
 
 var (

--- a/cachext/ext_test.go
+++ b/cachext/ext_test.go
@@ -51,7 +51,7 @@ func ExampleCacheExt_Cached() {
 		res[1] = keys[0]
 		return res, nil
 	}
-	cachedFunc, _ := cache.Cached(f, cachext.SetTTL(10*time.Second), cachext.SetVersion(1), cachext.SetMakeCacheKey(
+	cachedFunc, _ := cache.Cached("f", f, cachext.SetTTL(10*time.Second), cachext.SetVersion(1), cachext.SetMakeCacheKey(
 		func(funcName string, version int64, strArgs []string, intArgs []int64) string {
 			return strings.Join(strArgs, "_")
 		},
@@ -241,7 +241,7 @@ func TestCacheExt_Cached_Common(t *testing.T) {
 		res[1] = keys[0]
 		return res, nil
 	}
-	c_f_strs, _ := cache.Cached(f_strs, cachext.SetTTL(10*time.Second))
+	c_f_strs, _ := cache.Cached("f_strs", f_strs, cachext.SetTTL(10*time.Second))
 	cache_key := c_f_strs.MakeCacheKey([]string{"hello", "world"}, []int64{12})
 	cache.Delete(cache_key)
 	call_times = 0
@@ -269,7 +269,7 @@ func TestCacheExt_Cached_Common(t *testing.T) {
 		call_times += 1
 		return keys[0], nil
 	}
-	c_f_str, _ := cache.Cached(f_str, cachext.SetTTL(10*time.Second))
+	c_f_str, _ := cache.Cached("f_str", f_str, cachext.SetTTL(10*time.Second))
 	call_times = 0
 	str := ""
 
@@ -285,7 +285,7 @@ func TestCacheExt_Cached_Common(t *testing.T) {
 	}
 	// bool
 	f_bool := func(keys []string, args []int64) (interface{}, error) { call_times += 1; return true, nil }
-	c_f_bool, _ := cache.Cached(f_bool, cachext.SetTTL(10*time.Second))
+	c_f_bool, _ := cache.Cached("f_bool", f_bool, cachext.SetTTL(10*time.Second))
 	call_times = 0
 	res_bool := false
 
@@ -305,7 +305,7 @@ func TestCacheExt_Cached_Common(t *testing.T) {
 		call_times += 1
 		return []bool{true, false, true}, nil
 	}
-	c_f_bools, _ := cache.Cached(f_bools, cachext.SetTTL(10*time.Second))
+	c_f_bools, _ := cache.Cached("f_bools", f_bools, cachext.SetTTL(10*time.Second))
 	call_times = 0
 	bools := make([]bool, 3)
 	bools[0] = false
@@ -326,7 +326,7 @@ func TestCacheExt_Cached_Common(t *testing.T) {
 	}
 	// int
 	f_int := func(names []string, args []int64) (interface{}, error) { call_times += 1; return 1, nil }
-	c_f_int, _ := cache.Cached(f_int, cachext.SetTTL(10*time.Second))
+	c_f_int, _ := cache.Cached("f_int", f_int, cachext.SetTTL(10*time.Second))
 	call_times = 0
 	var int_res int
 	for i := 0; i <= 1; i++ {
@@ -346,7 +346,7 @@ func TestCacheExt_Cached_Common(t *testing.T) {
 		res[0] = 1
 		return res, nil
 	}
-	c_f_ints, _ := cache.Cached(f_ints, cachext.SetTTL(10*time.Second))
+	c_f_ints, _ := cache.Cached("f_ints", f_ints, cachext.SetTTL(10*time.Second))
 	call_times = 0
 	ints_res := make([]int, 1)
 	for i := 0; i <= 2; i++ {
@@ -364,7 +364,7 @@ func TestCacheExt_Cached_Common(t *testing.T) {
 		call_times += 1
 		return nil, nil
 	}
-	c_f_nil, _ := cache.Cached(f_nil, cachext.SetVersion(2), cachext.SetTTL(10*time.Second), cachext.SetCacheNil(false))
+	c_f_nil, _ := cache.Cached("f_nil", f_nil, cachext.SetVersion(2), cachext.SetTTL(10*time.Second), cachext.SetCacheNil(false))
 	nil_res := ""
 	call_times = 0
 	for i := 0; i <= 3; i++ {
@@ -376,7 +376,7 @@ func TestCacheExt_Cached_Common(t *testing.T) {
 	if call_times != 4 {
 		t.Log(nil_res, call_times)
 	}
-	cn_f_nil, _ := cache.Cached(f_nil, cachext.SetVersion(5), cachext.SetTTL(10*time.Second), cachext.SetCacheNil(true))
+	cn_f_nil, _ := cache.Cached("cn_f_nil", f_nil, cachext.SetVersion(5), cachext.SetTTL(10*time.Second), cachext.SetCacheNil(true))
 	call_times = 0
 	for i := 0; i <= 3; i++ {
 		err := cn_f_nil.GetResult(&nil_res, []string{}, []int64{})
@@ -391,12 +391,12 @@ func TestCacheExt_Cached_Common(t *testing.T) {
 	f_evil_nil := func(names []string, arg []int64) (interface{}, error) {
 		return []byte{192}, nil
 	}
-	c_f_evil_nil, _ := cache.Cached(f_evil_nil, cachext.SetTTL(10*time.Second), cachext.SetVersion(2), cachext.SetCacheNil(true))
+	c_f_evil_nil, _ := cache.Cached("f_evil_nil", f_evil_nil, cachext.SetTTL(10*time.Second), cachext.SetVersion(2), cachext.SetCacheNil(true))
 	if err := c_f_evil_nil.GetResult(&nil_res, []string{}, []int64{}); err == nil {
 		t.Log(nil_res, err, call_times)
 		t.Errorf("Evil Cache Nil happened")
 	}
-	c_f_kind_nil, _ := cache.Cached(f_evil_nil, cachext.SetTTL(10*time.Second), cachext.SetVersion(2))
+	c_f_kind_nil, _ := cache.Cached("c_f_kind_nil", f_evil_nil, cachext.SetTTL(10*time.Second), cachext.SetVersion(2))
 	if err := c_f_kind_nil.GetResult(&nil_res, []string{}, []int64{}); err != nil {
 		t.Log(nil_res, err, call_times)
 		t.Errorf("Evil Cache Nil happened")
@@ -436,7 +436,7 @@ func TestCacheExt_Cached_Struct(t *testing.T) {
 		mydata.Value3 = []node{node{"这是第一个node", []string{"id1", "id2", "id3"}}, node{"这是第二个node", []string{"id4", "id5", "id6"}}}
 		return mydata, nil
 	}
-	cached_complex_ff, _ := cache.Cached(complex_ff, cachext.SetTTL(10*time.Second))
+	cached_complex_ff, _ := cache.Cached("complex_ff", complex_ff, cachext.SetTTL(10*time.Second))
 	call_times = 0
 	data := myData{}
 	for i := 0; i <= 2; i++ {
@@ -540,7 +540,7 @@ func Benchmark_Cached(b *testing.B) {
 		many_map["5"] = "wewe"
 		return many_map, nil
 	}
-	cached_f, _ := cache.Cached(f, cachext.SetTTL(10*time.Second))
+	cached_f, _ := cache.Cached("f", f, cachext.SetTTL(10*time.Second))
 	for i := 0; i < b.N; i++ {
 		zero_map := make(map[string]string)
 		if err := cached_f.GetResult(&zero_map, []string{"hello"}, []int64{}); err != nil ||


### PR DESCRIPTION
反射获取函数名只能拿到函数顺序，实际使用中容易引起问题。例如：调整函数顺序时，会导致不同函数key互相重叠。
现有用法：
```go
// package models
var (
    cachedFunc1 *cachext.CacheOption
    cachedFunc2 *cachext.CacheOption
)
func InitCache(){
    // 如果这里添加另外的定义，会使用func1的cachekey，引起错乱
    cachedFunc1, _ := cache.Cached(func([]string, []int64)(interface{}, error){...}, cachext.SetTTL(10*time.Hour))
    cachedFunc2, _ := cache.Cached(func([]string, []int64)(interface{}, error){...},  cachext.SetTTL(10*time.Hour))
}
```
现在调整一下创建CachedFunc的方式，用法如下：
```go
// package models
var (
    cachedFunc1 *cachext.CacheOption
    cachedFunc2 *cachext.CacheOption
)
func InitCache(){
    cachedFunc1, _ := cache.Cached("func1", func([]string, []int64)(interface{}, error){...},  cachext.SetTTL(10*time.Hour))
    cachedFunc2, _ := cache.Cached("func2", func([]string, []int64)(interface{}, error){...},  cachext.SetTTL(10*time.Hour))
}
```