### PR TITLE
Add apm support for cachext & gormext

### DIFF
--- a/cachext/backend/memory/memory.go
+++ b/cachext/backend/memory/memory.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"context"
 	"github.com/shanbay/gobay/cachext"
 	"github.com/spf13/viper"
 	"time"
@@ -24,6 +25,10 @@ type memoryBackend struct {
 func (m *memoryBackend) Init(*viper.Viper) error {
 	m.client = make(map[string]*memoryBackendNode)
 	return nil
+}
+
+func (m *memoryBackend) WithContext(ctx context.Context) cachext.CacheBackend {
+	return m
 }
 
 func (m *memoryBackend) Get(key string) ([]byte, error) {

--- a/cachext/backend/redis/redis.go
+++ b/cachext/backend/redis/redis.go
@@ -1,9 +1,11 @@
 package redis
 
 import (
+	"context"
 	"github.com/go-redis/redis"
 	"github.com/shanbay/gobay/cachext"
 	"github.com/spf13/viper"
+	"go.elastic.co/apm/module/apmgoredis"
 	"time"
 )
 
@@ -29,6 +31,10 @@ func (b *redisBackend) Init(config *viper.Viper) error {
 	b.client = redisClient
 	_, err := redisClient.Ping().Result()
 	return err
+}
+
+func (b *redisBackend) WithContext(ctx context.Context) cachext.CacheBackend {
+	return &redisBackend{client: apmgoredis.Wrap(b.client).WithContext(ctx).RedisClient()}
 }
 
 func (b *redisBackend) Get(key string) ([]byte, error) {

--- a/cachext/ext_test.go
+++ b/cachext/ext_test.go
@@ -1,6 +1,7 @@
 package cachext_test
 
 import (
+	"context"
 	"fmt"
 	"github.com/shanbay/gobay"
 	"github.com/shanbay/gobay/cachext"
@@ -44,14 +45,14 @@ func ExampleCacheExt_Cached() {
 	var call_times = 0
 	var err error
 
-	f := func(keys []string, arg []int64) (interface{}, error) {
+	f := func(_ context.Context, keys []string, arg []int64) (interface{}, error) {
 		call_times += 1
 		res := make([]string, 2)
 		res[0] = keys[0]
 		res[1] = keys[0]
 		return res, nil
 	}
-	cachedFunc, _ := cache.Cached("f", f, cachext.SetTTL(10*time.Second), cachext.SetVersion(1), cachext.SetMakeCacheKey(
+	cachedFunc := cache.Cached("f", f, cachext.WithTTL(10*time.Second), cachext.WithVersion(1), cachext.WithMakeCacheKey(
 		func(funcName string, version int64, strArgs []string, intArgs []int64) string {
 			return strings.Join(strArgs, "_")
 		},
@@ -59,11 +60,11 @@ func ExampleCacheExt_Cached() {
 
 	zero_res := make([]string, 2)
 	for i := 0; i <= 1; i++ {
-		if err := cachedFunc.GetResult(&zero_res, []string{"hello", "world"}, []int64{}); err != nil {
+		if err := cachedFunc.GetResult(context.Background(), &zero_res, []string{"hello", "world"}, []int64{}); err != nil {
 			fmt.Println("Cache set Failed")
 		}
 	}
-	err = cachedFunc.GetResult(&zero_res, []string{"hello", "world"}, []int64{})
+	err = cachedFunc.GetResult(context.Background(), &zero_res, []string{"hello", "world"}, []int64{})
 	fmt.Println(zero_res, call_times, err)
 	// Output: [hello hello] 1 <nil>
 }
@@ -234,85 +235,88 @@ func TestCacheExt_Cached_Common(t *testing.T) {
 	call_times := 0
 	// common 主要测试返回值为： []string string bool []bool int []int nil
 	// []string
-	f_strs := func(keys []string, args []int64) (interface{}, error) {
+	f_strs := func(_ context.Context, keys []string, args []int64) (interface{}, error) {
 		call_times += 1
 		res := make([]string, 2)
 		res[0] = keys[0]
 		res[1] = keys[0]
 		return res, nil
 	}
-	c_f_strs, _ := cache.Cached("f_strs", f_strs, cachext.SetTTL(10*time.Second))
+	c_f_strs := cache.Cached("f_strs", f_strs, cachext.WithTTL(10*time.Second))
 	cache_key := c_f_strs.MakeCacheKey([]string{"hello", "world"}, []int64{12})
 	cache.Delete(cache_key)
 	call_times = 0
 	str_list := make([]string, 2)
 
 	for i := 0; i <= 2; i++ {
-		err := c_f_strs.GetResult(&str_list, []string{"hello", "world"}, []int64{12})
+		err := c_f_strs.GetResult(context.Background(), &str_list, []string{"hello", "world"}, []int64{12})
 		if err != nil {
 			t.Errorf("GetResult failed")
 		}
 	}
 	str_list = make([]string, 2)
-	if err := c_f_strs.GetResult(&str_list, []string{"hello", "world"}, []int64{12}); err != nil || str_list[0] != "hello" || str_list[1] != "hello" || call_times != 1 {
+	if err := c_f_strs.GetResult(context.Background(), &str_list, []string{"hello", "world"}, []int64{12}); err != nil || str_list[0] != "hello" || str_list[1] != "hello" || call_times != 1 {
 		t.Log(str_list, err, call_times)
 		t.Errorf("Cache str_list failed")
 	}
 	// make cache key
 	cache.Delete(cache_key)
-	if err := c_f_strs.GetResult(&str_list, []string{"hello", "world"}, []int64{12}); call_times != 2 {
+	if err := c_f_strs.GetResult(context.Background(), &str_list, []string{"hello", "world"}, []int64{12}); call_times != 2 {
 		t.Log(str_list, err, call_times)
 		t.Errorf("Cache str_list failed")
 	}
 	// string
-	f_str := func(keys []string, args []int64) (interface{}, error) {
+	f_str := func(_ context.Context, keys []string, args []int64) (interface{}, error) {
 		call_times += 1
 		return keys[0], nil
 	}
-	c_f_str, _ := cache.Cached("f_str", f_str, cachext.SetTTL(10*time.Second))
+	c_f_str := cache.Cached("f_str", f_str, cachext.WithTTL(10*time.Second))
 	call_times = 0
 	str := ""
 
 	for i := 0; i <= 2; i++ {
-		err := c_f_str.GetResult(&str, []string{"hello"}, []int64{})
+		err := c_f_str.GetResult(context.Background(), &str, []string{"hello"}, []int64{})
 		if err != nil {
 			t.Errorf("GetResult failed")
 		}
 	}
-	if err := c_f_str.GetResult(&str, []string{"hello"}, []int64{}); str != "hello" || err != nil || call_times != 1 {
+	if err := c_f_str.GetResult(context.Background(), &str, []string{"hello"}, []int64{}); str != "hello" || err != nil || call_times != 1 {
 		t.Log(str, err, call_times)
 		t.Errorf("Cached str failed")
 	}
 	// bool
-	f_bool := func(keys []string, args []int64) (interface{}, error) { call_times += 1; return true, nil }
-	c_f_bool, _ := cache.Cached("f_bool", f_bool, cachext.SetTTL(10*time.Second))
+	f_bool := func(_ context.Context, keys []string, args []int64) (interface{}, error) {
+		call_times += 1
+		return true, nil
+	}
+	c_f_bool := cache.Cached("f_bool", f_bool, cachext.WithTTL(10*time.Second))
 	call_times = 0
 	res_bool := false
 
 	for i := 0; i <= 1; i++ {
-		err := c_f_bool.GetResult(&res_bool, []string{"hello", "world"}, []int64{})
+		err := c_f_bool.GetResult(context.Background(), &res_bool, []string{"hello", "world"}, []int64{})
 		if err != nil {
 			t.Errorf("GetResult failed")
 		}
 	}
 	res_bool = false
-	if err := c_f_bool.GetResult(&res_bool, []string{"hello", "world"}, []int64{}); !res_bool || err != nil || call_times != 1 {
+	if err := c_f_bool.GetResult(context.Background(), &res_bool, []string{"hello", "world"}, []int64{}); !res_bool || err != nil || call_times != 1 {
 		t.Log(res_bool, err, call_times)
 		t.Errorf("Cached bool failed")
 	}
 	// []bool
-	f_bools := func(keys []string, args []int64) (interface{}, error) {
+	f_bools := func(_ context.Context, keys []string, args []int64) (interface{}, error) {
 		call_times += 1
 		return []bool{true, false, true}, nil
 	}
-	c_f_bools, _ := cache.Cached("f_bools", f_bools, cachext.SetTTL(10*time.Second))
+	c_f_bools := cache.Cached("f_bools", f_bools, cachext.WithTTL(10*time.Second))
 	call_times = 0
 	bools := make([]bool, 3)
 	bools[0] = false
 	bools[1] = false
 	bools[2] = false
 	for i := 0; i <= 1; i++ {
-		err := c_f_bools.GetResult(&bools, []string{}, []int64{})
+		err := c_f_bools.GetResult(context.Background(), &bools, []string{}, []int64{})
 		if err != nil {
 			t.Errorf("GetResult failed")
 		}
@@ -320,55 +324,58 @@ func TestCacheExt_Cached_Common(t *testing.T) {
 	bools[0] = false
 	bools[1] = false
 	bools[2] = false
-	if err := c_f_bools.GetResult(&bools, []string{}, []int64{}); bools[0] != true || err != nil || call_times != 1 {
+	if err := c_f_bools.GetResult(context.Background(), &bools, []string{}, []int64{}); bools[0] != true || err != nil || call_times != 1 {
 		t.Log(bools, err, call_times)
 		t.Errorf("Cached []bool failed")
 	}
 	// int
-	f_int := func(names []string, args []int64) (interface{}, error) { call_times += 1; return 1, nil }
-	c_f_int, _ := cache.Cached("f_int", f_int, cachext.SetTTL(10*time.Second))
+	f_int := func(_ context.Context, names []string, args []int64) (interface{}, error) {
+		call_times += 1
+		return 1, nil
+	}
+	c_f_int := cache.Cached("f_int", f_int, cachext.WithTTL(10*time.Second))
 	call_times = 0
 	var int_res int
 	for i := 0; i <= 1; i++ {
-		err := c_f_int.GetResult(&int_res, []string{"well"}, []int64{})
+		err := c_f_int.GetResult(context.Background(), &int_res, []string{"well"}, []int64{})
 		if err != nil {
 			t.Errorf("GetResult failed")
 		}
 	}
-	if err := c_f_int.GetResult(&int_res, []string{"well"}, []int64{}); int_res != 1 || err != nil || call_times != 1 {
+	if err := c_f_int.GetResult(context.Background(), &int_res, []string{"well"}, []int64{}); int_res != 1 || err != nil || call_times != 1 {
 		t.Log(int_res, err, call_times)
 		t.Errorf("Cached int failed")
 	}
 	// []int
-	f_ints := func(names []string, arg []int64) (interface{}, error) {
+	f_ints := func(_ context.Context, names []string, arg []int64) (interface{}, error) {
 		call_times += 1
 		res := make([]int, 1)
 		res[0] = 1
 		return res, nil
 	}
-	c_f_ints, _ := cache.Cached("f_ints", f_ints, cachext.SetTTL(10*time.Second))
+	c_f_ints := cache.Cached("f_ints", f_ints, cachext.WithTTL(10*time.Second))
 	call_times = 0
 	ints_res := make([]int, 1)
 	for i := 0; i <= 2; i++ {
-		err := c_f_ints.GetResult(&ints_res, []string{"hello"}, []int64{})
+		err := c_f_ints.GetResult(context.Background(), &ints_res, []string{"hello"}, []int64{})
 		if err != nil {
 			t.Errorf("GetResult failed")
 		}
 	}
-	if err := c_f_ints.GetResult(&ints_res, []string{"hello"}, []int64{}); ints_res[0] != 1 || err != nil || call_times != 1 {
+	if err := c_f_ints.GetResult(context.Background(), &ints_res, []string{"hello"}, []int64{}); ints_res[0] != 1 || err != nil || call_times != 1 {
 		t.Log(ints_res, err, call_times)
 		t.Errorf("Cached []int failed")
 	}
 	// nil
-	f_nil := func(names []string, arg []int64) (interface{}, error) {
+	f_nil := func(_ context.Context, names []string, arg []int64) (interface{}, error) {
 		call_times += 1
 		return nil, nil
 	}
-	c_f_nil, _ := cache.Cached("f_nil", f_nil, cachext.SetVersion(2), cachext.SetTTL(10*time.Second), cachext.SetCacheNil(false))
+	c_f_nil := cache.Cached("f_nil", f_nil, cachext.WithVersion(2), cachext.WithTTL(10*time.Second), cachext.WithCacheNil(false))
 	nil_res := ""
 	call_times = 0
 	for i := 0; i <= 3; i++ {
-		err := c_f_nil.GetResult(&nil_res, []string{}, []int64{})
+		err := c_f_nil.GetResult(context.Background(), &nil_res, []string{}, []int64{})
 		if err != cachext.Nil {
 			t.Errorf("Not Cache Nil failed")
 		}
@@ -376,10 +383,10 @@ func TestCacheExt_Cached_Common(t *testing.T) {
 	if call_times != 4 {
 		t.Log(nil_res, call_times)
 	}
-	cn_f_nil, _ := cache.Cached("cn_f_nil", f_nil, cachext.SetVersion(5), cachext.SetTTL(10*time.Second), cachext.SetCacheNil(true))
+	cn_f_nil := cache.Cached("cn_f_nil", f_nil, cachext.WithVersion(5), cachext.WithTTL(10*time.Second), cachext.WithCacheNil(true))
 	call_times = 0
 	for i := 0; i <= 3; i++ {
-		err := cn_f_nil.GetResult(&nil_res, []string{}, []int64{})
+		err := cn_f_nil.GetResult(context.Background(), &nil_res, []string{}, []int64{})
 		if err != cachext.Nil {
 			t.Errorf("Cache Nil failed")
 		}
@@ -388,16 +395,16 @@ func TestCacheExt_Cached_Common(t *testing.T) {
 		t.Log(nil_res, call_times)
 	}
 	// nil 测试函数返回值与cacheNil预设值冲突时，报错情况
-	f_evil_nil := func(names []string, arg []int64) (interface{}, error) {
+	f_evil_nil := func(_ context.Context, names []string, arg []int64) (interface{}, error) {
 		return []byte{192}, nil
 	}
-	c_f_evil_nil, _ := cache.Cached("f_evil_nil", f_evil_nil, cachext.SetTTL(10*time.Second), cachext.SetVersion(2), cachext.SetCacheNil(true))
-	if err := c_f_evil_nil.GetResult(&nil_res, []string{}, []int64{}); err == nil {
+	c_f_evil_nil := cache.Cached("f_evil_nil", f_evil_nil, cachext.WithTTL(10*time.Second), cachext.WithVersion(2), cachext.WithCacheNil(true))
+	if err := c_f_evil_nil.GetResult(context.Background(), &nil_res, []string{}, []int64{}); err == nil {
 		t.Log(nil_res, err, call_times)
 		t.Errorf("Evil Cache Nil happened")
 	}
-	c_f_kind_nil, _ := cache.Cached("c_f_kind_nil", f_evil_nil, cachext.SetTTL(10*time.Second), cachext.SetVersion(2))
-	if err := c_f_kind_nil.GetResult(&nil_res, []string{}, []int64{}); err != nil {
+	c_f_kind_nil := cache.Cached("c_f_kind_nil", f_evil_nil, cachext.WithTTL(10*time.Second), cachext.WithVersion(2))
+	if err := c_f_kind_nil.GetResult(context.Background(), &nil_res, []string{}, []int64{}); err != nil {
 		t.Log(nil_res, err, call_times)
 		t.Errorf("Evil Cache Nil happened")
 	}
@@ -426,7 +433,7 @@ func TestCacheExt_Cached_Struct(t *testing.T) {
 		Value3 []node
 		Value4 string
 	}
-	complex_ff := func(strArgs []string, intArgs []int64) (interface{}, error) {
+	complex_ff := func(_ context.Context, strArgs []string, intArgs []int64) (interface{}, error) {
 		call_times += 1
 		mydata := myData{}
 		mydata.Value1 = 100
@@ -436,17 +443,17 @@ func TestCacheExt_Cached_Struct(t *testing.T) {
 		mydata.Value3 = []node{node{"这是第一个node", []string{"id1", "id2", "id3"}}, node{"这是第二个node", []string{"id4", "id5", "id6"}}}
 		return mydata, nil
 	}
-	cached_complex_ff, _ := cache.Cached("complex_ff", complex_ff, cachext.SetTTL(10*time.Second))
+	cached_complex_ff := cache.Cached("complex_ff", complex_ff, cachext.WithTTL(10*time.Second))
 	call_times = 0
 	data := myData{}
 	for i := 0; i <= 2; i++ {
-		err := cached_complex_ff.GetResult(&data, []string{"hell"}, []int64{})
+		err := cached_complex_ff.GetResult(context.Background(), &data, []string{"hell"}, []int64{})
 		if err != nil {
 			t.Errorf("GetResult failed")
 		}
 	}
 	data = myData{}
-	err := cached_complex_ff.GetResult(&data, []string{"hell"}, []int64{})
+	err := cached_complex_ff.GetResult(context.Background(), &data, []string{"hell"}, []int64{})
 	if call_times != 1 || err != nil || data.Value4 != "some str" {
 		t.Log(data, err, call_times)
 		t.Errorf("Cached struct failed")
@@ -531,7 +538,7 @@ func Benchmark_Cached(b *testing.B) {
 		fmt.Println(err)
 		return
 	}
-	f := func(name []string, args []int64) (interface{}, error) {
+	f := func(_ context.Context, name []string, args []int64) (interface{}, error) {
 		many_map := make(map[string]string)
 		many_map["1"] = "hello"
 		many_map["2"] = "wewe"
@@ -540,10 +547,10 @@ func Benchmark_Cached(b *testing.B) {
 		many_map["5"] = "wewe"
 		return many_map, nil
 	}
-	cached_f, _ := cache.Cached("f", f, cachext.SetTTL(10*time.Second))
+	cached_f := cache.Cached("Benchmark_Cached", f, cachext.WithTTL(10*time.Second))
 	for i := 0; i < b.N; i++ {
 		zero_map := make(map[string]string)
-		if err := cached_f.GetResult(&zero_map, []string{"hello"}, []int64{}); err != nil ||
+		if err := cached_f.GetResult(context.Background(), &zero_map, []string{"hello"}, []int64{}); err != nil ||
 			zero_map["1"] != "hello" ||
 			zero_map["2"] != "wewe" ||
 			zero_map["3"] != "true" ||

--- a/esapmext/ext.go
+++ b/esapmext/ext.go
@@ -27,8 +27,7 @@ func (e *EsApmExt) Application() *gobay.Application {
 func (e *EsApmExt) Init(app *gobay.Application) error {
 
 	config := app.Config()
-	apmEnable := config.GetBool("elastic_apm_enable")
-	if !apmEnable {
+	if !config.GetBool("elastic_apm_enable") {
 		return nil
 	}
 	// elastic apm load config from env by default
@@ -37,6 +36,7 @@ func (e *EsApmExt) Init(app *gobay.Application) error {
 	if env == "" {
 		env = app.Env()
 	}
+
 	tracer := apm.DefaultTracer
 	tracer.Service.Environment = env
 	tracer.Service.Name = config.GetString("elastic_apm_service_name")

--- a/esapmext/ext.go
+++ b/esapmext/ext.go
@@ -25,15 +25,19 @@ func (e *EsApmExt) Application() *gobay.Application {
 
 // https://www.elastic.co/guide/en/apm/agent/go/current/configuration.html
 func (e *EsApmExt) Init(app *gobay.Application) error {
-	tracer := apm.DefaultTracer
 
 	config := app.Config()
+	apmEnable := config.GetBool("elastic_apm_enable")
+	if !apmEnable {
+		return nil
+	}
 	// elastic apm load config from env by default
 	// use `elastic_apm` as config prefix so we can make compatible with default agent behavior
 	env := config.GetString("elastic_apm_environment")
 	if env == "" {
 		env = app.Env()
 	}
+	tracer := apm.DefaultTracer
 	tracer.Service.Environment = env
 	tracer.Service.Name = config.GetString("elastic_apm_service_name")
 	tracer.Service.Version = config.GetString("elastic_apm_service_version")

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/shanbay/gobay
 go 1.13
 
 require (
-	github.com/facebookincubator/ent v0.0.0-20191218131918-1bbe460259f9
 	github.com/RichardKnop/machinery v1.7.2
+	github.com/facebookincubator/ent v0.0.0-20191218131918-1bbe460259f9
 	github.com/getsentry/sentry-go v0.3.1
 	github.com/go-openapi/runtime v0.19.9
 	github.com/go-redis/redis v6.15.6+incompatible
@@ -21,6 +21,8 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/vmihailenco/msgpack v4.0.4+incompatible
 	go.elastic.co/apm v1.6.0
+	go.elastic.co/apm/module/apmgoredis v1.6.0
+	go.elastic.co/apm/module/apmgorm v1.6.0
 	go.elastic.co/apm/module/apmsql v1.6.0
 	golang.org/x/net v0.0.0-20191014212845-da9a3fd4c582 // indirect
 	golang.org/x/sys v0.0.0-20191020212454-3e7259c5e7c2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.37.4/go.mod h1:NHPJ89PdicEuT9hdPXMROBD91xc5uRDxsMtSB16k7hw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
+cloud.google.com/go v0.40.0/go.mod h1:Tk58MuI9rbLMKlAjeO/bDnteAx7tX2gJIXw4T5Jwlro=
 cloud.google.com/go v0.44.1/go.mod h1:iSa0KzasP4Uvy3f1mN/7PiObzGgflwredwwASm/v6AU=
 cloud.google.com/go v0.44.2/go.mod h1:60680Gw3Yr4ikxnPRS/oxxkBccT6SA1yMk63TGekxKY=
 cloud.google.com/go v0.45.1/go.mod h1:RpBamKRgapWJb87xiFSdk4g1CME7QZg3uwTez+TSTjc=
@@ -22,6 +23,7 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/CloudyKit/fastprinter v0.0.0-20170127035650-74b38d55f37a/go.mod h1:EFZQ978U7x8IRnstaskI3IysnWY5Ao3QgZUKOXlsAdw=
 github.com/CloudyKit/jet v2.1.3-0.20180809161101-62edd43e4f88+incompatible/go.mod h1:HPYO+50pSWkPoj9Q/eq0aRGByCL6ScRlUmiEX5Zgm+w=
+github.com/DATA-DOG/go-sqlmock v1.3.3 h1:CWUqKXe0s8A2z6qCgkP4Kru7wC11YoAnoupUKFDnH08=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
 github.com/Joker/jade v1.0.1-0.20190614124447-d475f43051e7/go.mod h1:6E6s8o2AE4KhCrqr6GRJjdC/gNfTdxkIXvuGZZda2VM=
@@ -33,8 +35,6 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/RichardKnop/logging v0.0.0-20190827224416-1a693bdd4fae h1:DcFpTQBYQ9Ct2d6sC7ol0/ynxc2pO1cpGUM+f4t5adg=
 github.com/RichardKnop/logging v0.0.0-20190827224416-1a693bdd4fae/go.mod h1:rJJ84PyA/Wlmw1hO+xTzV2wsSUon6J5ktg0g8BF2PuU=
-github.com/RichardKnop/machinery v1.7.1 h1:k9iu5GrVGAfa6B9jdSR0UbyqcHTr1pnAsK9kLefX+TM=
-github.com/RichardKnop/machinery v1.7.1/go.mod h1:Ud9v7j7+DrjQgC7gMqFdcIWJBCJMeXmhgr0saIlPGEw=
 github.com/RichardKnop/machinery v1.7.2 h1:TwRiIBpHkH73HNadbLBcEFHFBXL9iAyJ19tKP/4m9tc=
 github.com/RichardKnop/machinery v1.7.2/go.mod h1:Ud9v7j7+DrjQgC7gMqFdcIWJBCJMeXmhgr0saIlPGEw=
 github.com/RichardKnop/redsync v1.2.0 h1:gK35hR3zZkQigHKm8wOGb9MpJ9BsrW6MzxezwjTcHP0=
@@ -56,6 +56,7 @@ github.com/aws/aws-sdk-go v1.25.8 h1:n7I+HUUXjun2CsX7JK+1hpRIkZrlKhd3nayeb+Xmavs
 github.com/aws/aws-sdk-go v1.25.8/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
+github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b h1:L/QXpzIa3pOvUGt1D1lA5KjYhPBAN/3iWdP7xeFS9F0=
 github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b/go.mod h1:H0wQNHz2YrLsuXOZozoeDmnHXkNCRmMW0gwFWDfEZDA=
@@ -92,7 +93,6 @@ github.com/elastic/go-sysinfo v1.0.1 h1:lzGPX2sIXaETeMXitXL2XZU8K4B7k7JBhIKWxdOd
 github.com/elastic/go-sysinfo v1.0.1/go.mod h1:O/D5m1VpYLwGjCYzEt63g3Z1uO3jXfwyzzjiW90t8cY=
 github.com/elastic/go-windows v1.0.0 h1:qLURgZFkkrYyTTkvYpsZIgf83AUsdIHfvlJaqaZ7aSY=
 github.com/elastic/go-windows v1.0.0/go.mod h1:TsU0Nrp7/y3+VwE82FoZF8gC/XFg/Elz6CcloAxnPgU=
-github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 h1:Yzb9+7DPaBjB8zlTR87/ElzFsnQfuHnVUVqpZZIcV5Y=
@@ -152,8 +152,6 @@ github.com/go-openapi/loads v0.19.3/go.mod h1:YVfqhUCdahYwR3f3iiwQLhicVRvLlU/WO5
 github.com/go-openapi/runtime v0.0.0-20180920151709-4f900dc2ade9/go.mod h1:6v9a6LTXWQCdL8k1AO3cvqx5OtZY/Y9wKTgaoP6YRfA=
 github.com/go-openapi/runtime v0.19.0/go.mod h1:OwNfisksmmaZse4+gpV3Ne9AyMOlP1lt4sK4FXt0O64=
 github.com/go-openapi/runtime v0.19.4/go.mod h1:X277bwSUBxVlCYR3r7xgZZGKVvBd/29gLDlFGtJ8NL4=
-github.com/go-openapi/runtime v0.19.8 h1:la3rOpJ+UnJSCgsgMv/xKHCMCpKJtFVa7ai4mPnV2ts=
-github.com/go-openapi/runtime v0.19.8/go.mod h1:dhGWCTKRXlAfGnQG0ONViOZpjfg0m2gUt9nTQPQZuoo=
 github.com/go-openapi/runtime v0.19.9 h1:Ay3ckvUJy9iTA4F6EWjx4c2/o3dfHiYdwJbOqIvGLx4=
 github.com/go-openapi/runtime v0.19.9/go.mod h1:dhGWCTKRXlAfGnQG0ONViOZpjfg0m2gUt9nTQPQZuoo=
 github.com/go-openapi/spec v0.17.0/go.mod h1:XkF/MOi14NmjsfZ8VtAKf8pIlbZzyoTvZsdfssdxcBI=
@@ -176,6 +174,7 @@ github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+
 github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2KDnRCRMUi7GTA=
 github.com/go-openapi/validate v0.19.3 h1:PAH/2DylwWcIU1s0Y7k3yNmeAgWOcKrNE2Q7Ww/kCg4=
 github.com/go-openapi/validate v0.19.3/go.mod h1:90Vh6jjkTn+OT1Eefm0ZixWNFjhtOH7vS9k0lo6zwJo=
+github.com/go-redis/redis v6.15.3-0.20190424063336-97e6ed817821+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/go-redis/redis v6.15.6+incompatible h1:H9evprGPLI8+ci7fxQx6WNZHJSb7be8FqJQRhdQZ5Sg=
 github.com/go-redis/redis v6.15.6+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/go-sql-driver/mysql v1.4.1-0.20190510102335-877a9775f068/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
@@ -226,6 +225,7 @@ github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
@@ -233,6 +233,7 @@ github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoA
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.1.0 h1:THDBEeQ9xZ8JEaCLyLQqXMMdRqNr0QAUJTIkQAUtFjg=
 github.com/grpc-ecosystem/go-grpc-middleware v1.1.0/go.mod h1:f5nM7jw/oeRSadq3xCzHAvxcr8HZnzsqU6ILg/0NiiE=
+github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
@@ -249,6 +250,7 @@ github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/
 github.com/iris-contrib/i18n v0.0.0-20171121225848-987a633949d0/go.mod h1:pMCz62A0xJL6I+umB2YTlFRwWXaDFA0jy+5HzGiJjqI=
 github.com/iris-contrib/schema v0.0.1/go.mod h1:urYA3uvUNG1TIIjOSCzHr9/LmbQo8LrOcOqfqxa4hXw=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jinzhu/gorm v1.9.10/go.mod h1:Kh6hTsSGffh4ui079FHrR5Gg+5D0hgihqDcsDN2BBJY=
 github.com/jinzhu/gorm v1.9.11 h1:gaHGvE+UnWGlbWG4Y3FUwY1EcZ5n6S9WtqBA/uySMLE=
 github.com/jinzhu/gorm v1.9.11/go.mod h1:bu/pK8szGZ2puuErfU0RwyeNdsf3e6nCX/noXaVxkfw=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
@@ -264,6 +266,7 @@ github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCV
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfEUpgAwUN0o=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/juju/errors v0.0.0-20181118221551-089d3ea4e4d5/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/loggo v0.0.0-20180524022052-584905176618/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
@@ -296,6 +299,7 @@ github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.1.1 h1:sJZmqHoEaY7f+NPP8pgLB/WxulyR3fewgCM2qaSlBb4=
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/lib/pq v1.2.0 h1:LXpIM/LZ5xGFhOpXAQUIMM1HdyqzVYM13zNdjCEEcA0=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
@@ -316,6 +320,7 @@ github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsO
 github.com/mattn/go-sqlite3 v1.13.0 h1:LnJI81JidiW9r7pS/hXe6cFeO5EXNq7KbfvoJLRI69c=
 github.com/mattn/go-sqlite3 v1.13.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
+github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mediocregopher/mediocre-go-lib v0.0.0-20181029021733-cb65787f37ed/go.mod h1:dSsfyI2zABAdhcbvkXqgxOxrCsbYeHCPgrZkku60dSg=
 github.com/mediocregopher/radix/v3 v3.3.0/go.mod h1:EmfVyvspXz1uZEyPBMyGK+kjWiKQGvsUt6O3Pj+LDCQ=
@@ -334,10 +339,12 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.3 h1:OoxbjfXVZyod1fmWYhI7SEyaD8B00ynP3T+D5GiyHOY=
 github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1 h1:K0jcRCwNQM3vFGh1ppMtDh/+7ApJrjldlX8fA0jDTLQ=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
@@ -357,13 +364,16 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=
+github.com/prometheus/client_golang v0.9.3 h1:9iH4JKXLzFbOAdtqv/a+j8aewx2Y8lAjAydhbaScPF8=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 h1:gQz4mCbXsO+nc9n1hCxHcGA3Zx3Eo+UHZoInFGUIXNM=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.2.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
+github.com/prometheus/common v0.4.0 h1:7etb9YClo3a6HjLzfl6rIQaU+FDfi0VSX39io3aQ+DM=
 github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
@@ -387,7 +397,9 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
@@ -402,8 +414,6 @@ github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb6
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
-github.com/spf13/viper v1.5.0 h1:GpsTwfsQ27oS/Aha/6d1oD7tpKIqWnOA6tgOX9HHkt4=
-github.com/spf13/viper v1.5.0/go.mod h1:AkYRkVJF8TkSG/xet6PzXX+l39KhhXa2pdqVSxnTcn4=
 github.com/spf13/viper v1.6.1 h1:VPZzIkznI1YhVMRi6vNFLHSwhnhReBfgTxIPccpfdZk=
 github.com/spf13/viper v1.6.1/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271 h1:WhxRHzgeVGETMlmVfqhRn8RIeeNoPr2Czh33I4Zdccw=
@@ -449,6 +459,10 @@ github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82/go.mod h1:lgjkn3NuSvDf
 github.com/yudai/pp v2.0.1+incompatible/go.mod h1:PuxR/8QJ7cyCkFp/aUDS+JY727OFEZkTdatxwunjIkc=
 go.elastic.co/apm v1.6.0 h1:RzyNj9Qx2iXh4A8DIg/aMUdtwGFNw3R8sKO3/Hf4pqk=
 go.elastic.co/apm v1.6.0/go.mod h1:/VByR6FBtuNu1YnPHz7Gri7YiIqAoFBGVp+2xkSE8tI=
+go.elastic.co/apm/module/apmgoredis v1.6.0 h1:E/4nyzB8yo1zX1BduAzFpvs/45fq8csMXZyYB+7d3A0=
+go.elastic.co/apm/module/apmgoredis v1.6.0/go.mod h1:2A858ngLiX0/IqNEPPLoUVXT5v527UK0MD7JMEVrWJM=
+go.elastic.co/apm/module/apmgorm v1.6.0 h1:E1CANwa6+xdRUwMBSqgYILIK1mvrFzqIsW/6QYJXjsk=
+go.elastic.co/apm/module/apmgorm v1.6.0/go.mod h1:pnpRtjjQ7CJbq9c3OIIcpDq1vbumitJQFhKvOUkSbdw=
 go.elastic.co/apm/module/apmsql v1.6.0 h1:0vMQDYFtA7G6QgGai38CmYY5ki9Q6g/ub/jCQp8/7qU=
 go.elastic.co/apm/module/apmsql v1.6.0/go.mod h1:cmMxjn6l+tjYM9+/sYnlhyGOFcj5Ye+P2NW2yslp/N8=
 go.elastic.co/fastjson v1.0.0 h1:ooXV/ABvf+tBul26jcVViPT3sBir0PvXgibYB1IQQzg=
@@ -592,10 +606,12 @@ golang.org/x/tools v0.0.0-20190917162342-3b4f30a44f3b/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20190927191325-030b2cf1153e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191007185444-6536af71d98a h1:mtF1GhqcFEC1RVSQxvgrZWOM22dax6fiM9VfcQoTv6U=
 golang.org/x/tools v0.0.0-20191007185444-6536af71d98a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a h1:TwMENskLwU2NnWBzrJGEWHqSiGUkO/B4rfyhwqDxDYQ=
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
+google.golang.org/api v0.6.0/go.mod h1:btoxGiFvQNVUZQ8W08zLtrVS08CNpINPEfxXxgJL1Q4=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
 google.golang.org/api v0.9.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
@@ -613,6 +629,7 @@ google.golang.org/genproto v0.0.0-20190404172233-64821d5d2107/go.mod h1:VzzqZJRn
 google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
+google.golang.org/genproto v0.0.0-20190530194941-fb225487d101/go.mod h1:z3L6/3dTEVtUr6QSP8miRzeRqwQOioJ9I66odjN4I7s=
 google.golang.org/genproto v0.0.0-20190801165951-fa694d86fc64/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20190911173649-1774047e7e51/go.mod h1:IbNlFCBrqXvoKpeg0TB2l7cyZUmoaFKYIwrEpbDKLA8=
@@ -627,8 +644,6 @@ google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ij
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.24.0/go.mod h1:XDChyiUovWa60DnaeDeZmSW86xtLtjtZbwvSiRnRtcA=
-google.golang.org/grpc v1.25.1 h1:wdKvqQk7IttEw92GoRyKG2IDrUIpgpj6H6m81yfeMW0=
-google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.26.0 h1:2dTRdpdFEEhJYQD8EMLB61nnrzSCTbG38PhqdhvOltg=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=


### PR DESCRIPTION
cachext & gormext with apm useage:(**TEST ENV:  KIBANA:6.5.0 APM_SERVER:6.5.0**)
```yaml
// config.yaml
elastic_apm_enable: true
```
```go
// models.go
require "go.elastic.co/apm/module/apmgorm"
func WordLogAggCheckExist(ctx context.Context, userId uint64, vocabIds []uint64) (interface{}, error) {
    apmDB := apmgorm.WithContext(ctx, myapp.DB) // ctx from handlers
    apmDB.Where(...).Find(...)
    return nil, nil
}
```
```go
//models.go
cachedFunc = myapp.Cache.Cached(
    "cacheFuncCacheKey",
    func(ctx context.Context, strArgs []string, intArgs []int64) (interface{}, error) {
        return WordLogAggCheckExist(ctx, intArgs[0], intArgs[1:])
    },
    cachext.WithTTL(12*time.Hour),
)
cachedFunc.GetResult(ctx, &out, []string{}, []int64{})  // ctx from handlers
apmCache := myapp.Cache.WithContext(ctx)  // ctx from handlers
apmCache.Get("cache key", &out)
```
