### PR TITLE
Add DB() to ent

### DIFF
--- a/extensions/entext/ext.go
+++ b/extensions/entext/ext.go
@@ -65,3 +65,8 @@ func (d *EntExt) Init(app *gobay.Application) error {
 }
 
 func (d *EntExt) Close() error { return d.client.Close() }
+
+// DB 获取数据库，ent目前还不够完善，某些场景下还需要执行sql
+func (d *EntExt) DB() *sql.DB {
+	return d.drv.DB()
+}


### PR DESCRIPTION
ent目前功能有限，有些场景不能很好的支持，比如主键名称必须为 `id`。而目前项目中存在主键不是`id`的表。添加DB方法供使用者执行sql。