### PR TITLE
Use RegisterTasks

### DIFF
--- a/extensions/asynctaskext/asynctaskext.go
+++ b/extensions/asynctaskext/asynctaskext.go
@@ -60,9 +60,9 @@ func (t *AsyncTaskExt) Close() error {
 	return nil
 }
 
-//RegisterWorkerHandler add task handler to worker to process task messages
-func (t *AsyncTaskExt) RegisterWorkerHandler(name string, handler interface{}) error {
-	return t.server.RegisterTask(name, handler)
+//RegisterWorkerHandlers add task handlers to worker to process task messages
+func (t *AsyncTaskExt) RegisterWorkerHandlers(handlers map[string]interface{}) error {
+	return t.server.RegisterTasks(handlers)
 }
 
 //StartWorker start a worker that consume task messages for queue

--- a/extensions/asynctaskext/asynctaskext_test.go
+++ b/extensions/asynctaskext/asynctaskext_test.go
@@ -31,7 +31,7 @@ func init() {
 }
 
 func TestPushConsume(t *testing.T) {
-	if err := task.RegisterWorkerHandler("add", TaskAdd); err != nil {
+	if err := task.RegisterWorkerHandlers(map[string]interface{}{"add": TaskAdd}); err != nil {
 		t.Error(err)
 	}
 	go func() {


### PR DESCRIPTION
使用 RegisterTasks 一次注册全部 task 更加直观。
之前的写法:
```go
if err := asynctask.RegisterWorkerHandler("create", Create); err != nil {
    panic(err)
}
if err := asynctask.RegisterWorkerHandler("update", Update); err != nil {
    panic(err)
}
if err := asynctask.RegisterWorkerHandler("delete", Delete); err != nil {
    panic(err)
}
```
修改后：
```go
if err := asynctask.RegisterWorkerHandlers(map[string]interface{}{
        "create": Create,
        "update": Update,
        "delete": Delete,
}); err != nil {
    panic(err)
}
```