### PR TITLE
Remove WithContext from cachext

### DIFF
--- a/extensions/cachext/backend/memory/memory.go
+++ b/extensions/cachext/backend/memory/memory.go
@@ -29,64 +29,60 @@ func (m *memoryBackend) Init(*viper.Viper) error {
 	return nil
 }
 
-func (m *memoryBackend) WithContext(ctx context.Context) cachext.CacheBackend {
-	return m
-}
-
-func (m *memoryBackend) Get(key string) ([]byte, error) {
+func (m *memoryBackend) Get(ctx context.Context, key string) ([]byte, error) {
 	res, exists := m.client[key]
 	if !exists {
 		return nil, nil
 	}
 	if res.ExpiredAt.Before(time.Now()) {
-		m.Delete(key)
+		m.Delete(ctx, key)
 		return nil, nil
 	} else {
 		return res.Value, nil
 	}
 }
 
-func (m *memoryBackend) Set(key string, value []byte, ttl time.Duration) error {
+func (m *memoryBackend) Set(ctx context.Context, key string, value []byte, ttl time.Duration) error {
 	node := &memoryBackendNode{Value: value, ExpiredAt: time.Now().Add(ttl)}
 	m.client[key] = node
 	return nil
 }
 
-func (m *memoryBackend) SetMany(keyValues map[string][]byte, ttl time.Duration) error {
+func (m *memoryBackend) SetMany(ctx context.Context, keyValues map[string][]byte, ttl time.Duration) error {
 	for key, value := range keyValues {
-		if err := m.Set(key, value, ttl); err != nil {
+		if err := m.Set(ctx, key, value, ttl); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (m *memoryBackend) GetMany(keys []string) [][]byte {
+func (m *memoryBackend) GetMany(ctx context.Context, keys []string) [][]byte {
 	resBytes := make([][]byte, len(keys))
 	for i, key := range keys {
-		resBytes[i], _ = m.Get(key)
+		resBytes[i], _ = m.Get(ctx, key)
 	}
 	return resBytes
 }
 
-func (m *memoryBackend) Delete(key string) bool {
-	exists := m.Exists(key)
+func (m *memoryBackend) Delete(ctx context.Context, key string) bool {
+	exists := m.Exists(ctx, key)
 	delete(m.client, key)
 	return exists
 }
 
-func (m *memoryBackend) DeleteMany(keys []string) bool {
+func (m *memoryBackend) DeleteMany(ctx context.Context, keys []string) bool {
 	var res bool
 	for _, key := range keys {
-		if m.Delete(key) {
+		if m.Delete(ctx, key) {
 			res = true
 		}
 	}
 	return res
 }
 
-func (m *memoryBackend) Expire(key string, ttl time.Duration) bool {
-	val, _ := m.Get(key)
+func (m *memoryBackend) Expire(ctx context.Context, key string, ttl time.Duration) bool {
+	val, _ := m.Get(ctx, key)
 	if val == nil {
 		return false
 	}
@@ -94,8 +90,8 @@ func (m *memoryBackend) Expire(key string, ttl time.Duration) bool {
 	return true
 }
 
-func (m *memoryBackend) TTL(key string) time.Duration {
-	_, _ = m.Get(key)
+func (m *memoryBackend) TTL(ctx context.Context, key string) time.Duration {
+	_, _ = m.Get(ctx, key)
 	val := m.client[key]
 	if val == nil {
 		return 0
@@ -103,8 +99,8 @@ func (m *memoryBackend) TTL(key string) time.Duration {
 	return time.Until(val.ExpiredAt)
 }
 
-func (m *memoryBackend) Exists(key string) bool {
-	val, _ := m.Get(key)
+func (m *memoryBackend) Exists(ctx context.Context, key string) bool {
+	val, _ := m.Get(ctx, key)
 	if val == nil {
 		return false
 	} else {

--- a/extensions/cachext/backend/redis/redis.go
+++ b/extensions/cachext/backend/redis/redis.go
@@ -21,6 +21,10 @@ type redisBackend struct {
 	client *redis.Client
 }
 
+func (b *redisBackend) withContext(ctx context.Context) *redis.Client {
+	return apmgoredis.Wrap(b.client).WithContext(ctx).RedisClient()
+}
+
 func (b *redisBackend) Init(config *viper.Viper) error {
 	host := config.GetString("host")
 	password := config.GetString("password")
@@ -35,37 +39,37 @@ func (b *redisBackend) Init(config *viper.Viper) error {
 	return err
 }
 
-func (b *redisBackend) WithContext(ctx context.Context) cachext.CacheBackend {
-	return &redisBackend{client: apmgoredis.Wrap(b.client).WithContext(ctx).RedisClient()}
-}
-
-func (b *redisBackend) Get(key string) ([]byte, error) {
-	val, err := b.client.Get(key).Result()
+func (b *redisBackend) Get(ctx context.Context, key string) ([]byte, error) {
+	client := b.withContext(ctx)
+	val, err := client.Get(key).Result()
 	if err == redis.Nil {
 		return nil, nil
 	}
 	return ([]byte)(val), nil
 }
 
-func (b *redisBackend) Set(key string, value []byte, ttl time.Duration) error {
-	return b.client.Set(key, value, ttl).Err()
+func (b *redisBackend) Set(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	client := b.withContext(ctx)
+	return client.Set(key, value, ttl).Err()
 }
 
-func (b *redisBackend) SetMany(keyValues map[string][]byte, ttl time.Duration) error {
+func (b *redisBackend) SetMany(ctx context.Context, keyValues map[string][]byte, ttl time.Duration) error {
 	pairs := make([]interface{}, 2*len(keyValues))
 	for key, value := range keyValues {
 		pairs = append(pairs, key, value)
 	}
-	b.client.MSet(pairs...)
+	client := b.withContext(ctx)
+	client.MSet(pairs...)
 	for key := range keyValues {
-		b.client.Expire(key, ttl)
+		client.Expire(key, ttl)
 	}
 	return nil
 }
 
-func (b *redisBackend) GetMany(keys []string) [][]byte {
+func (b *redisBackend) GetMany(ctx context.Context, keys []string) [][]byte {
 	res := make([][]byte, len(keys))
-	for i, value := range b.client.MGet(keys...).Val() {
+	client := b.withContext(ctx)
+	for i, value := range client.MGet(keys...).Val() {
 		if value != nil {
 			res[i] = ([]byte)(value.(string))
 		}
@@ -73,28 +77,32 @@ func (b *redisBackend) GetMany(keys []string) [][]byte {
 	return res
 }
 
-func (b *redisBackend) Delete(key string) bool {
+func (b *redisBackend) Delete(ctx context.Context, key string) bool {
 	keys := make([]string, 1)
 	keys[0] = key
-	return b.DeleteMany(keys)
+	return b.DeleteMany(ctx, keys)
 }
 
-func (b *redisBackend) DeleteMany(keys []string) bool {
-	return b.client.Del(keys...).Val() == 1
+func (b *redisBackend) DeleteMany(ctx context.Context, keys []string) bool {
+	client := b.withContext(ctx)
+	return client.Del(keys...).Val() == 1
 }
 
-func (b *redisBackend) Expire(key string, ttl time.Duration) bool {
-	return b.client.Expire(key, ttl).Val()
+func (b *redisBackend) Expire(ctx context.Context, key string, ttl time.Duration) bool {
+	client := b.withContext(ctx)
+	return client.Expire(key, ttl).Val()
 }
 
-func (b *redisBackend) TTL(key string) time.Duration {
-	return b.client.TTL(key).Val()
+func (b *redisBackend) TTL(ctx context.Context, key string) time.Duration {
+	client := b.withContext(ctx)
+	return client.TTL(key).Val()
 }
 
-func (b *redisBackend) Exists(key string) bool {
+func (b *redisBackend) Exists(ctx context.Context, key string) bool {
 	keys := make([]string, 1)
 	keys[0] = key
-	res := b.client.Exists(keys...)
+	client := b.withContext(ctx)
+	res := client.Exists(keys...)
 	return res.Val() == 1
 }
 

--- a/extensions/cachext/cached.go
+++ b/extensions/cachext/cached.go
@@ -57,13 +57,7 @@ func (c *CachedConfig) MakeCacheKey(strArgs []string, intArgs []int64) string {
 // GetResult
 func (c *CachedConfig) GetResult(ctx context.Context, out interface{}, strArgs []string, intArgs []int64) error {
 	cacheKey := c.MakeCacheKey(strArgs, intArgs)
-	var backend CacheBackend
-	if c.cache.enableApm {
-		backend = c.cache.backend.WithContext(ctx)
-	} else {
-		backend = c.cache.backend
-	}
-	data, err := backend.Get(c.cache.transKey(cacheKey))
+	data, err := c.cache.backend.Get(ctx, c.cache.transKey(cacheKey))
 	if err != nil {
 		return err
 	}
@@ -91,7 +85,7 @@ func (c *CachedConfig) GetResult(ctx context.Context, out interface{}, strArgs [
 	case cacheNilHited:
 		// Set nil 会保存一个[]byte{192}的结构到backend中
 		nilBytes, _ := encode(nil)
-		if err = backend.Set(c.cache.transKey(cacheKey), nilBytes, c.ttl); err != nil {
+		if err = c.cache.backend.Set(ctx, c.cache.transKey(cacheKey), nilBytes, c.ttl); err != nil {
 			return err
 		}
 		return Nil
@@ -102,7 +96,7 @@ func (c *CachedConfig) GetResult(ctx context.Context, out interface{}, strArgs [
 		if encodedBytes, err := encode(res); err != nil {
 			return err
 		} else {
-			err = backend.Set(c.cache.transKey(cacheKey), encodedBytes, c.ttl)
+			err = c.cache.backend.Set(ctx, c.cache.transKey(cacheKey), encodedBytes, c.ttl)
 			if err != nil {
 				return err
 			}

--- a/extensions/cachext/ext.go
+++ b/extensions/cachext/ext.go
@@ -21,7 +21,6 @@ type CacheExt struct {
 	prefix         string
 	initialized    bool
 	cachedFuncName map[string]void
-	enableApm      bool
 }
 
 var (
@@ -47,7 +46,7 @@ type CacheBackend interface {
 // Init init a cache extension
 func (c *CacheExt) Init(app *gobay.Application) error {
 	if c.NS == "" {
-		return errors.New("lack of NS")
+		return errors.New("cachext: lack of NS")
 	}
 	mu.Lock()
 	defer mu.Unlock()
@@ -58,7 +57,6 @@ func (c *CacheExt) Init(app *gobay.Application) error {
 	c.app = app
 	c.cachedFuncName = make(map[string]void)
 	config := app.Config()
-	c.enableApm = config.GetBool("elastic_apm_enable")
 	config = gobay.GetConfigByPrefix(config, c.NS, true)
 	c.prefix = config.GetString("prefix")
 	backendConfig := config.GetString("backend")

--- a/extensions/cachext/ext_test.go
+++ b/extensions/cachext/ext_test.go
@@ -23,10 +23,10 @@ func ExampleCacheExt_Set() {
 	}
 
 	var key = "cache_key"
-	err := cache.Set(key, "hello", 10*time.Second)
+	err := cache.Set(context.Background(), key, "hello", 10*time.Second)
 	fmt.Println(err)
 	var res string
-	exists, err := cache.Get(key, &res)
+	exists, err := cache.Get(context.Background(), key, &res)
 	fmt.Println(exists, res, err)
 	// Output:
 	// <nil>
@@ -83,7 +83,7 @@ func ExampleCacheExt_SetMany() {
 	many_map := make(map[string]interface{})
 	many_map["1"] = "hello"
 	many_map["2"] = []bool{true, true}
-	err := cache.SetMany(many_map, 10*time.Second)
+	err := cache.SetMany(context.Background(), many_map, 10*time.Second)
 	fmt.Println(err)
 
 	many_res := make(map[string]interface{})
@@ -92,7 +92,7 @@ func ExampleCacheExt_SetMany() {
 	val2 := []bool{}
 	many_res["1"] = &str1
 	many_res["2"] = &val2
-	err = cache.GetMany(many_res)
+	err = cache.GetMany(context.Background(), many_res)
 	fmt.Println(err, *(many_res["1"].(*string)), *(many_res["2"].(*[]bool)))
 	// Output: <nil>
 	// <nil> hello [true true]
@@ -109,11 +109,11 @@ func TestCacheExt_Operation(t *testing.T) {
 	}
 
 	// Get Set
-	if err := cache.Set("cache_key_1", "100", 10*time.Second); err != nil {
+	if err := cache.Set(context.Background(), "cache_key_1", "100", 10*time.Second); err != nil {
 		t.Errorf("Cache Set Key Failed")
 	}
 	var cache_val string
-	if exists, err := cache.Get("cache_key_1", &cache_val); exists == false || err != nil || cache_val != "100" {
+	if exists, err := cache.Get(context.Background(), "cache_key_1", &cache_val); exists == false || err != nil || cache_val != "100" {
 		t.Log(exists, cache_val, err)
 		t.Errorf("Cache Get Key Failed")
 	}
@@ -131,12 +131,12 @@ func TestCacheExt_Operation(t *testing.T) {
 	mydata.Value1 = 100
 	mydata.Value2 = "thre si a verty conplex data {}{}"
 	mydata.Value3 = []node{node{"这是第一个node", []string{"id1", "id2", "id3"}}, node{"这是第二个node", []string{"id4", "id5", "id6"}}}
-	if err := cache.Set("cache_key_2", mydata, 10*time.Second); err != nil {
+	if err := cache.Set(context.Background(), "cache_key_2", mydata, 10*time.Second); err != nil {
 		t.Log(err)
 		t.Errorf("Cache Set Failed")
 	}
 	val := &myData{}
-	if exist, err := cache.Get("cache_key_2", val); (*val).Value2 != mydata.Value2 || err != nil || exist == false {
+	if exist, err := cache.Get(context.Background(), "cache_key_2", val); (*val).Value2 != mydata.Value2 || err != nil || exist == false {
 		t.Log(exist, err, *val)
 		t.Errorf("Cache Get Failed")
 	}
@@ -145,7 +145,7 @@ func TestCacheExt_Operation(t *testing.T) {
 	many_map["m1"] = "hello"
 	many_map["m2"] = "100"
 	many_map["m3"] = "true"
-	if err := cache.SetMany(many_map, 10*time.Second); err != nil {
+	if err := cache.SetMany(context.Background(), many_map, 10*time.Second); err != nil {
 		t.Log(err)
 		t.Errorf("Cache SetMany Failed")
 	}
@@ -156,7 +156,7 @@ func TestCacheExt_Operation(t *testing.T) {
 	many_res["m1"] = &str1
 	many_res["m2"] = &str2
 	many_res["m3"] = &str3
-	if err := cache.GetMany(many_res); err != nil ||
+	if err := cache.GetMany(context.Background(), many_res); err != nil ||
 		*(many_res["m1"].(*string)) != "hello" ||
 		*(many_res["m2"].(*string)) != "100" ||
 		*(many_res["m3"].(*string)) != "true" {
@@ -164,59 +164,59 @@ func TestCacheExt_Operation(t *testing.T) {
 		t.Errorf("Cache GetMany Failed")
 	}
 	// Delete Exists
-	if err := cache.Set("cache_key_3", "golang", 10*time.Second); err != nil {
+	if err := cache.Set(context.Background(), "cache_key_3", "golang", 10*time.Second); err != nil {
 		t.Errorf("Cache set Failed")
 	}
-	if err := cache.Set("cache_key_4", "gobay", 10*time.Second); err != nil {
+	if err := cache.Set(context.Background(), "cache_key_4", "gobay", 10*time.Second); err != nil {
 		t.Errorf("Cache set Failed")
 	}
-	if res := cache.Exists("cache_key_3"); res != true {
+	if res := cache.Exists(context.Background(), "cache_key_3"); res != true {
 		t.Log(res)
 		t.Errorf("Cache Exists Failed")
 	}
-	if res := cache.Delete("cache_key_3"); res != true {
+	if res := cache.Delete(context.Background(), "cache_key_3"); res != true {
 		t.Log(res)
 		t.Errorf("Cache Delete Failed")
 	}
-	if res := cache.Exists("cache_key_3"); res != false {
+	if res := cache.Exists(context.Background(), "cache_key_3"); res != false {
 		t.Log(res)
 		t.Errorf("Cache Exists Failed")
 	}
-	if res := cache.Delete("cache_key_3"); res != false {
+	if res := cache.Delete(context.Background(), "cache_key_3"); res != false {
 		t.Log(res)
 		t.Errorf("Cache Delete Failed")
 	}
 	// DeleteMany
 	keys := []string{"cache_key_3", "cache_key_4"}
-	if res := cache.Exists("cache_key_4"); res != true {
+	if res := cache.Exists(context.Background(), "cache_key_4"); res != true {
 		t.Log(res)
 		t.Errorf("Cache Exists Failed")
 	}
-	if res := cache.DeleteMany(keys...); res != true {
+	if res := cache.DeleteMany(context.Background(), keys...); res != true {
 		t.Log(res)
 		t.Errorf("Cache DeleteMany Failed")
 	}
-	if res := cache.Exists("cache_key_4"); res != false {
+	if res := cache.Exists(context.Background(), "cache_key_4"); res != false {
 		t.Log(res)
 		t.Errorf("Cache Exists Failed")
 	}
-	if res := cache.DeleteMany(keys...); res != false {
+	if res := cache.DeleteMany(context.Background(), keys...); res != false {
 		t.Log(res)
 		t.Errorf("Cache DeleteMany Failed")
 	}
 	// Expire TTL
-	if err := cache.Set("cache_key_4", "hello", 10*time.Second); err != nil {
+	if err := cache.Set(context.Background(), "cache_key_4", "hello", 10*time.Second); err != nil {
 		t.Errorf("Cache set Failed")
 	}
-	if res := cache.TTL("cache_key_4"); res < 9*time.Second || res > 10*time.Second {
+	if res := cache.TTL(context.Background(), "cache_key_4"); res < 9*time.Second || res > 10*time.Second {
 		t.Log(res)
 		t.Errorf("Cache TTL Failed")
 	}
-	if res := cache.Expire("cache_key_4", 20*time.Second); res != true {
+	if res := cache.Expire(context.Background(), "cache_key_4", 20*time.Second); res != true {
 		t.Log(res)
 		t.Errorf("Cache Expire Failed")
 	}
-	if res := cache.TTL("cache_key_4"); res < 19*time.Second || res > 20*time.Second {
+	if res := cache.TTL(context.Background(), "cache_key_4"); res < 19*time.Second || res > 20*time.Second {
 		t.Log(res)
 		t.Errorf("Cache TTL Failed")
 	}
@@ -245,7 +245,7 @@ func TestCacheExt_Cached_Common(t *testing.T) {
 	}
 	c_f_strs := cache.Cached("f_strs", f_strs, cachext.WithTTL(10*time.Second))
 	cache_key := c_f_strs.MakeCacheKey([]string{"hello", "world"}, []int64{12})
-	cache.Delete(cache_key)
+	cache.Delete(context.Background(), cache_key)
 	call_times = 0
 	str_list := make([]string, 2)
 
@@ -261,7 +261,7 @@ func TestCacheExt_Cached_Common(t *testing.T) {
 		t.Errorf("Cache str_list failed")
 	}
 	// make cache key
-	cache.Delete(cache_key)
+	cache.Delete(context.Background(), cache_key)
 	if err := c_f_strs.GetResult(context.Background(), &str_list, []string{"hello", "world"}, []int64{12}); call_times != 2 {
 		t.Log(str_list, err, call_times)
 		t.Errorf("Cache str_list failed")
@@ -480,7 +480,7 @@ func Benchmark_SetMany(b *testing.B) {
 	many_map["4"].(map[string]int)["2"] = 900
 	many_map["4"].(map[string]int)["3"] = 1200
 	for i := 0; i < b.N; i++ {
-		err := cache.SetMany(many_map, 10*time.Second)
+		err := cache.SetMany(context.Background(), many_map, 10*time.Second)
 		if err != nil {
 			fmt.Println(err)
 		}
@@ -506,7 +506,7 @@ func Benchmark_GetMany(b *testing.B) {
 	many_map["6"].(map[string]int)["1"] = 200
 	many_map["6"].(map[string]int)["2"] = 900
 	many_map["6"].(map[string]int)["3"] = 1200
-	if err := cache.SetMany(many_map, 10*time.Second); err != nil {
+	if err := cache.SetMany(context.Background(), many_map, 10*time.Second); err != nil {
 		fmt.Println(err)
 	}
 	for i := 0; i < b.N; i++ {
@@ -524,7 +524,7 @@ func Benchmark_GetMany(b *testing.B) {
 		many_res["5"] = &val5
 		val6 := make(map[string]interface{})
 		many_res["6"] = &val6
-		if err := cache.GetMany(many_res); err != nil {
+		if err := cache.GetMany(context.Background(), many_res); err != nil {
 			fmt.Println(err)
 		}
 	}


### PR DESCRIPTION
- 把context作为参数传递更加符合context的定位。
- WithContext 由于不调用也能正常使用cache，因此很容易忘记写，进而导致apm无法跟踪cache。
```go
// 改动之前
cache := app.Cache.WithContext(ctx)
cache.Set("some cache key", "some value")

// 改之后
cache.Set(ctx, "some cache key", "some value")
```