### PR TITLE
fix cache ext

### DIFF
--- a/extensions/cachext/backend/memory/memory.go
+++ b/extensions/cachext/backend/memory/memory.go
@@ -10,7 +10,7 @@ import (
 )
 
 func init() {
-	if err := cachext.RegisteBackend("memory", &memoryBackend{}); err != nil {
+	if err := cachext.RegisteBackend("memory", func() cachext.CacheBackend { return &memoryBackend{} }); err != nil {
 		panic("MemoryBackend Init error")
 	}
 }

--- a/extensions/cachext/backend/redis/redis.go
+++ b/extensions/cachext/backend/redis/redis.go
@@ -12,7 +12,7 @@ import (
 )
 
 func init() {
-	if err := cachext.RegisteBackend("redis", &redisBackend{}); err != nil {
+	if err := cachext.RegisteBackend("redis", func() cachext.CacheBackend { return &redisBackend{} }); err != nil {
 		panic("RedisBackend init error")
 	}
 }


### PR DESCRIPTION
现在init ext的时候会覆盖旧的backend的redis实例，改为每次Init ext的时候给一个新的backend