### PR TITLE
fix: close nil apm trace

### DIFF
--- a/extensions/esapmext/ext.go
+++ b/extensions/esapmext/ext.go
@@ -67,6 +67,8 @@ func (e *EsApmExt) Init(app *gobay.Application) error {
 }
 
 func (e *EsApmExt) Close() error {
-	e.tracer.Close()
+	if e.tracer != nil {
+		e.tracer.Close()
+	}
 	return nil
 }


### PR DESCRIPTION
初始化EsApmExt中的tracer时，tracer可以为nil， 但是关闭EsApmExt的时候tracer为空会报错