### PR TITLE
openapi sentry mw: default repanic

### DIFF
--- a/extensions/sentryext/openapi/mw.go
+++ b/extensions/sentryext/openapi/mw.go
@@ -13,6 +13,9 @@ func GetMiddleWare(d *sentryext.SentryExt) (middleware.Builder, error) {
 	if err := config.Unmarshal(&o); err != nil {
 		return nil, err
 	}
+	if !config.IsSet("repanic") {
+		o.Repanic = true
+	}
 	handler := sentryhttp.New(o)
 	return handler.Handle, nil
 }


### PR DESCRIPTION
目前可以配置`sentry_repanic: true`来做到，但默认是false。其实大多数情况下都是sentry捕获完希望能再抛出来的。