### PR TITLE
enhance healthcheck

### DIFF
--- a/cmd/gobay/templates/app/extensions.go.tmpl
+++ b/cmd/gobay/templates/app/extensions.go.tmpl
@@ -67,10 +67,12 @@ var (
 {{- if not $.SkipAsyncTask }}
 	AsyncTask *asynctaskext.AsyncTaskExt
 {{- end }}
+	// EntExt         *entext.EntExt
 	// EntClient *schema.Client
 )
 
 func InitExts(app *gobay.Application) {
+	// EntExt = app.Get("entext").(*entext.EntExt)
 	// EntClient = app.Get("entext").Object().(*schema.Client)
 	Redis = app.Get("redis").Object().(*redisext.RedisExt)
 	Seqgen = app.Get("seqgen").Object().(*seqgenext.SequenceGeneratorExt)

--- a/cmd/gobay/templates/app/grpc/handlers.go.tmpl
+++ b/cmd/gobay/templates/app/grpc/handlers.go.tmpl
@@ -14,6 +14,24 @@ type {{ toLowerCamel $.Name }}Server struct {
 
 func (s *{{ toLowerCamel $.Name }}Server) Check(ctx context.Context, req *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
 	if req.Service == "liveness" || req.Service == "readiness" {
+		// if app.EntExt != nil {
+		// 	if err := app.EntClient.CheckHealth(ctx); err != nil {
+		// 		return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_NOT_SERVING}, nil
+		// 	}
+		// }
+
+		if app.Redis != nil {
+			if err := app.Redis.CheckHealth(ctx); err != nil {
+				return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_NOT_SERVING}, nil
+			}
+		}
+
+		if app.Cache != nil {
+			if err := app.Cache.CheckHealth(ctx); err != nil {
+				return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_NOT_SERVING}, nil
+			}
+		}
+
 		return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING}, nil
 	}
 	return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_UNKNOWN}, nil

--- a/cmd/gobay/templates/app/openapi/handlers.go.tmpl
+++ b/cmd/gobay/templates/app/openapi/handlers.go.tmpl
@@ -13,13 +13,31 @@ type {{ toLowerCamel $.Name }}Server struct {
 func (s *{{ toLowerCamel $.Name }}Server) healthCheckHealthHandler() health.HealthCheckHandler {
 	return health.HealthCheckHandlerFunc(func(params health.HealthCheckParams) middleware.Responder {
 		if params.Type == nil {
-                        return health.NewHealthCheckNotFound()
+			return health.NewHealthCheckNotFound()
 		}
-                check_type := *params.Type
+		check_type := *params.Type
 		if check_type == "liveness" || check_type == "readiness" {
-                        return health.NewHealthCheckOK()
+			ctx := params.HTTPRequest.Context()
+			// if app.EntExt != nil {
+			// 	if err := app.EntClient.CheckHealth(ctx); err != nil {
+			// 		return health.NewHealthCheckNotFound()
+			// 	}
+			// }
+	
+			if app.Redis != nil {
+				if err := app.Redis.CheckHealth(ctx); err != nil {
+					return health.NewHealthCheckNotFound()
+				}
+			}
+	
+			if app.Cache != nil {
+				if err := app.Cache.CheckHealth(ctx); err != nil {
+					return health.NewHealthCheckNotFound()
+				}
+			}
+			return health.NewHealthCheckOK()
 		} else {
-                        return health.NewHealthCheckNotFound()
+			return health.NewHealthCheckNotFound()
 		}
 	})
 }

--- a/cmd/gobay/templates/spec/enttmpl/client.tmpl
+++ b/cmd/gobay/templates/spec/enttmpl/client.tmpl
@@ -196,6 +196,15 @@ func (c *{{ $client }}) Get(ctx context.Context, id {{ $n.ID.Type }}) (*{{ $n.Na
 	return c.Query().Where({{ $n.Package }}.ID(id)).Only(ctx)
 }
 
+// CheckHealth try to read a first {{ $n.Name }} entity, okay if NotFound, returns the error if any other error happens.
+func (c *{{ $client }}) CheckHealth(ctx context.Context) (error) {
+	_, err := c.Query().Limit(1).Only(ctx)
+	if err != nil  && !schema.IsNotFound(err) {
+		return err
+	}
+	return nil
+}
+
 // GetX is like Get, but panics if an error occurs.
 func (c *{{ $client }}) GetX(ctx context.Context, id {{ $n.ID.Type }}) *{{ $n.Name }} {
 	{{ $rec }}, err := c.Get(ctx, id)

--- a/cmd/gobay/templates/spec/enttmpl/client.tmpl
+++ b/cmd/gobay/templates/spec/enttmpl/client.tmpl
@@ -55,6 +55,15 @@ func (c *Client) init() {
 	{{- end }}
 }
 
+func (c *Client) CheckHealth(ctx context.Context) error {
+	{{- range $n := $.Nodes }}
+			if err := c.{{ $n.Name }}.CheckHealth(ctx); err != nil {
+				return err
+			}
+	{{- end }}
+	return nil
+}
+
 // Open opens a database/sql.DB specified by the driver name and
 // the data source name, and returns a new client attached to it.
 // Optional parameters can be added for configuring the client.
@@ -199,7 +208,7 @@ func (c *{{ $client }}) Get(ctx context.Context, id {{ $n.ID.Type }}) (*{{ $n.Na
 // CheckHealth try to read a first {{ $n.Name }} entity, okay if NotFound, returns the error if any other error happens.
 func (c *{{ $client }}) CheckHealth(ctx context.Context) (error) {
 	_, err := c.Query().Limit(1).Only(ctx)
-	if err != nil  && !schema.IsNotFound(err) {
+	if err != nil  && !IsNotFound(err) {
 		return err
 	}
 	return nil

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,36 @@
+# 0.13.10 (2020-11-03)
+
+- 增强 health check
+
+GRPC 和 OpenAPI 的 health check 检查时，可以添加检查 Cache, Redis, 每个 DB。
+
+```go
+func (h *luneServer) Check(ctx context.Context, req *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	if req.Service == "liveness" || req.Service == "readiness" {
+		if app.EntExt != nil {
+			if err := app.EntClient.CheckHealth(ctx); err != nil {
+				return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_NOT_SERVING}, nil
+			}
+		}
+
+		if app.Redis != nil {
+			if err := app.Redis.CheckHealth(ctx); err != nil {
+				return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_NOT_SERVING}, nil
+			}
+		}
+
+		if app.Cache != nil {
+			if err := app.Cache.CheckHealth(ctx); err != nil {
+				return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_NOT_SERVING}, nil
+			}
+		}
+
+		return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING}, nil
+	}
+	return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_UNKNOWN}, nil
+}
+```
+
 # 0.13.9 (2020-10-16)
 
 - 添加 openapi 的 ent 报错处理 middleware 。 ent 报错后，把错误 panic 出来，可以自动处理 404 not found 和 400 constraint error。
@@ -11,6 +44,8 @@ mdwBuilders = append(mdwBuilders, entopenapimw.GetEntMw(myapp.EntExt))
 // 在这个之前
 s.SetHandler(gmw(api.Serve(openapi.ChainMiddlewares(...
 ```
+
+- 添加方便写测试的 testhelper ，详情参考 [/docs/writing_test.md](https://github.com/shanbay/gobay/blob/master/docs/writing_test.md)
 
 # 0.13.6 (2020-09-29)
 

--- a/extensions/cachext/backend/memory/memory.go
+++ b/extensions/cachext/backend/memory/memory.go
@@ -29,6 +29,10 @@ func (m *memoryBackend) Init(*viper.Viper) error {
 	return nil
 }
 
+func (m *memoryBackend) CheckHealth(ctx context.Context) error {
+	return nil
+}
+
 func (m *memoryBackend) Get(ctx context.Context, key string) ([]byte, error) {
 	res, exists := m.client[key]
 	if !exists {

--- a/extensions/cachext/backend/redis/redis.go
+++ b/extensions/cachext/backend/redis/redis.go
@@ -39,6 +39,15 @@ func (b *redisBackend) Init(config *viper.Viper) error {
 	return err
 }
 
+func (b *redisBackend) CheckHealth(ctx context.Context) error {
+	client := b.withContext(ctx)
+	_, err := client.Ping().Result()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (b *redisBackend) Get(ctx context.Context, key string) ([]byte, error) {
 	client := b.withContext(ctx)
 	val, err := client.Get(key).Result()

--- a/extensions/cachext/ext_test.go
+++ b/extensions/cachext/ext_test.go
@@ -33,6 +33,22 @@ func ExampleCacheExt_Set() {
 	// true hello <nil>
 }
 
+func ExampleCacheExt_CheckHealth() {
+	cache := &cachext.CacheExt{NS: "cache_"}
+	exts := map[gobay.Key]gobay.Extension{
+		"cache": cache,
+	}
+	if _, err := gobay.CreateApp("../../testdata/", "testing", exts); err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	err := cache.CheckHealth(context.Background())
+	fmt.Println(err)
+	// Output:
+	// <nil>
+}
+
 func ExampleCacheExt_Cached() {
 	cache := &cachext.CacheExt{NS: "cache_"}
 	exts := map[gobay.Key]gobay.Extension{

--- a/extensions/redisext/ext_test.go
+++ b/extensions/redisext/ext_test.go
@@ -9,6 +9,22 @@ import (
 	"github.com/shanbay/gobay/extensions/redisext"
 )
 
+func ExampleRedisExt_CheckHealth() {
+	redis := &redisext.RedisExt{NS: "redis_"}
+	exts := map[gobay.Key]gobay.Extension{
+		"redis": redis,
+	}
+	if _, err := gobay.CreateApp("../../testdata/", "testing", exts); err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	err := redis.CheckHealth(context.Background())
+	fmt.Println(err)
+	// Output:
+	// <nil>
+}
+
 func ExampleRedisExt_Set() {
 	redis := &redisext.RedisExt{NS: "redis_"}
 	exts := map[gobay.Key]gobay.Extension{


### PR DESCRIPTION
- [x] 添加 DB extension health check
- [x] 添加 Cache extension health check
- [x] 添加 Redis extension health check

-------------------------------------------
要使用的话，在GRPC和OpenAPI的 health check controller里，添加触发每种health check的逻辑

```go
if checkType == "liveness" || checkType == "readiness" {
  ctx := params.HTTPRequest.Context()
  if app.EntExt != nil {
    if err := app.EntClient.CheckHealth(ctx); err != nil {
      return health.NewHealthCheckNotFound()
    }
  }

  if app.Redis != nil {
    if err := app.Redis.CheckHealth(ctx); err != nil {
      return health.NewHealthCheckNotFound()
    }
  }

  if app.Cache != nil {
    if err := app.Cache.CheckHealth(ctx); err != nil {
      return health.NewHealthCheckNotFound()
    }
  }
  return health.NewHealthCheckOK()
}
```

-------------------------------------------
Cache 和 Redis:

extension 内添加 CheckHealth function , 
比如 `app.Cache.CheckHealth(ctx)` 就会在extension内调用 set -> get -> delete 缓存，来测试缓存使用是否正常。
如果缓存有问题（比如redis服务挂了），则可以检测到报错。

DB (ent):
生成Client的ent template中，添加检查每个 db table 用的 CheckHealth function。
比如 `app.EntClient.CheckHealth(ctx)` 就会去每个 DB 运行 `select * from xxx limit 1`，确保不止连接服务器正常，DB也正常可读。


