### PR TITLE
feature(log): log panic stack trace to stdout in sentry recovery

### DIFF
--- a/extensions/sentryext/grpc/mw.go
+++ b/extensions/sentryext/grpc/mw.go
@@ -3,6 +3,8 @@ package sentrygrpcmw
 import (
 	"context"
 	"errors"
+	"log"
+	"runtime/debug"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/grpc-ecosystem/go-grpc-middleware/recovery"
@@ -15,6 +17,10 @@ import (
 func GetOption(d *sentryext.SentryExt) grpc_recovery.Option {
 	return grpc_recovery.WithRecoveryHandlerContext(
 		func(ctx context.Context, err interface{}) error {
+			// log err and stack trace to stdout
+			log.Println(err)
+			log.Println(string(debug.Stack()))
+
 			hub := sentry.CurrentHub().Clone()
 			if hub == nil {
 				return errors.New("failed to get sentry hub")


### PR DESCRIPTION
对于 grpc server，sentry 在 recover 时增加打印到标准输出的操作