### PR TITLE
better lint

### DIFF
--- a/cmd/gobay/templates/.golangci.yml
+++ b/cmd/gobay/templates/.golangci.yml
@@ -8,4 +8,8 @@ run:
 
 linters:
   enable:
+    - goimports
+    - misspell
+    - gofumpt
     - gofmt
+    - gocritic

--- a/cmd/gobay/templates/.pre-commit-config.yaml
+++ b/cmd/gobay/templates/.pre-commit-config.yaml
@@ -14,3 +14,4 @@ repos:
     rev: v0.3.5
     hooks:
       - id: golangci-lint
+        args: [--fix]

--- a/cmd/gobay/templates/Makefile.tmpl
+++ b/cmd/gobay/templates/Makefile.tmpl
@@ -218,7 +218,7 @@ profile_all_stop: \
 # Format
 #
 
-.PHONY: fmt lint
+.PHONY: fmt lint lintfix
 
 # check code style in these directories
 FMT_DIRS = app cmd lib test
@@ -232,6 +232,9 @@ fmt:
 lint:
 	$(GOCI) run --timeout=3m --skip-dirs=gen
 	oapi-codegen -o /dev/null $(OAPI_SPEC)
+
+lintfix:
+	$(GOCI) run --skip-dirs=gen --fix
 
 #
 # Dependency management


### PR DESCRIPTION
## 改动描述

启用了下面的 golangci-lint 插件（下面是额外启用的插件，golangci-lint 本身就启用了一些）：

```
    - goimports  # import 顺序
    - misspell   # 英文拼写错误检查
    - gofumpt    # 一些写法的格式化：多余空行、变量定义、大括号位置等
    - gofmt      # 之前就在使用的 gofmt
    - gocritic   # 一些更严格的代码风格检查。注意，这个插件的告警无法自动修复，必须手动修改
```

pre-commit 的时候自动修复可以修复的部分。

Makefile 里增加了一个 `make lintfix` 命令，在本地可以执行这个修复代码（gocritic 除外）。

## 使用

生成完项目本地开发的时候，需要本地更新一下 golangci-lint 版本：

```
go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.35.2
```

没有挂 pre-commit 勾子的需要挂一下：

```
pre-commit install
```