### PR TITLE
尝试修复弱网环境时，同时收到两条ack消息往channel丢导致的阻塞问题

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,12 @@ jobs:
           path: $GOPATH/pkg/mod
           key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
 
-      - name: Before tests
-        if: ${{ env.GOENV_VERSION != '1.16' }}
+      - name: Before tests 1.14
+        if: ${{ env.GOENV_VERSION == '1.14' }}
+        run: |
+          go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.39.0
+      - name: Before tests 1.15
+        if: ${{ env.GOENV_VERSION == '1.15' }}
         run: |
           go install github.com/golangci/golangci-lint/cmd/golangci-lint
       - name: Before tests 1.16

--- a/extensions/busext/amqp.go
+++ b/extensions/busext/amqp.go
@@ -419,7 +419,7 @@ func (b *BusExt) changeConnection(connection *amqp.Connection) {
 func (b *BusExt) changeChannel(channel *amqp.Channel) {
 	b.channel = channel
 	b.notifyChanClose = make(chan *amqp.Error)
-	b.notifyConfirm = make(chan amqp.Confirmation, 1)
+	b.notifyConfirm = make(chan amqp.Confirmation, 5)
 	b.channel.NotifyClose(b.notifyChanClose)
 	b.channel.NotifyPublish(b.notifyConfirm)
 	log.Println("channel changed")


### PR DESCRIPTION
冲突的逻辑都在这个文件里，下面的问题描述的代码行数指这个文件的行数 https://github.com/streadway/amqp/blob/master/confirms.go

如果 channel 的 buffer 为 1，在弱网环境下可能之前发的消息没有收到 ack，所以在某一刻能可能发生这样的事件顺序：
1. 收到 ack，调用 61 行的 `One` 方法 -> `resequence` 调用 `confirm` 方法丢消息到 channel
2. 又收到一条 ack，调用 61 行的 `One` 方法 -> 取锁 -> `resequence` 调用 `confirm` 方法 -> 第 45 行尝试丢消息到 channel -> channel 阻塞（没有释放锁）
3. 我们正在主动发消息，走到 31 行的 `Publish` 方法 -> 取锁失败

这个时候就会一直阻塞住；简单来说是因为 buffer 是 1 但是同时收到两条 ack（虽然我们发消息是串行发的，但是确实能复现这种极端情况）。

尝试如果把 buffer 加到 5，在 10% 丢包率、延时 500ms 的弱网环境下尝试复现，不停地发消息跑了一小段时间并没有复现成功（如果 buffer 为 1 不停地发消息基本可以在一分钟内复现卡死）。可以认为收到 5 条的可能性是极小的。

---

缺点是弱网有延迟情况下，我们 ack 的那条可能就不是发的那一条了（虽然现在一样是不能确定的）

所以这个 PR 相比现状是没有损失的，而且解决了卡掉的问题

---

一个更好的解决方案是给 amqp 库提 PR 让 Publish （仅仅是一个自增）不要取锁而是使用 atomic

https://github.com/streadway/amqp/pull/508