### PR TITLE
fix stubext: Dialoptions; ChainInterceptor

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.17.0 (2021-10-09)
+
+- 修正 `DialOptions` 拼写
+- 修复启用 apm 的时候 retry 不生效的问题
+
+**BREAKING CHANGE**:
+
+初始化 stubext 时参数应该改叫 `DialOptions`
+
 # 0.16.0 (2021-08-16)
 
 - 改用 `shanbay/amqp`

--- a/extensions/stubext/ext_test.go
+++ b/extensions/stubext/ext_test.go
@@ -23,7 +23,7 @@ var (
 func setupStub(env string) {
 	stubext = StubExt{
 		NS:          "stub_health_",
-		DailOptions: []grpc.DialOption{grpc.WithInsecure(), grpc.WithBlock()},
+		DialOptions: []grpc.DialOption{grpc.WithInsecure(), grpc.WithBlock()},
 		NewClientFuncs: map[string]NewClientFunc{
 			"health": func(conn *grpc.ClientConn) interface{} {
 				return protos_go.NewHealthClient(conn)


### PR DESCRIPTION
- 拼写错误
- 应该使用 ChainXXXInterceptor，否则会是覆盖关系（启用 apm 时 retry 不生效）
- 把 per call opts 放到最里层（超时、重试）