### PR TITLE
fix cache nil

### DIFF
--- a/extensions/cachext/cached.go
+++ b/extensions/cachext/cached.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -87,7 +88,12 @@ func (c *CachedConfig) GetResult(ctx context.Context, out interface{}, strArgs [
 		return errors.New("Your response is conflict with cacheNil value")
 	}
 
-	status := [2]bool{res == nil, c.cacheNil} // 函数返回值与是否cacheNil状态判断
+	resIsNil := false
+	// res 储存的是一个有类型的 nil 指针时，`== nil` 是 false
+	if res == nil || (reflect.ValueOf(res).Kind() == reflect.Ptr && reflect.ValueOf(res).IsNil()) {
+		resIsNil = true
+	}
+	status := [2]bool{resIsNil, c.cacheNil} // 函数返回值与是否cacheNil状态判断
 	cacheNilHited := [2]bool{true, true}      // 函数返回值是nil，同时cacheNil。
 	noNeedCacheNil := [2]bool{true, false}    // 函数返回值是nil，不cacheNil。
 

--- a/extensions/cachext/ext_test.go
+++ b/extensions/cachext/ext_test.go
@@ -152,7 +152,7 @@ func TestCacheExt_Operation(t *testing.T) {
 	mydata := myData{}
 	mydata.Value1 = 100
 	mydata.Value2 = "thre si a verty conplex data {}{}"
-	mydata.Value3 = []node{node{"这是第一个node", []string{"id1", "id2", "id3"}}, node{"这是第二个node", []string{"id4", "id5", "id6"}}}
+	mydata.Value3 = []node{{"这是第一个node", []string{"id1", "id2", "id3"}}, {"这是第二个node", []string{"id4", "id5", "id6"}}}
 	if err := cache.Set(context.Background(), "cache_key_2", mydata, 10*time.Second); err != nil {
 		t.Log(err)
 		t.Errorf("Cache Set Failed")
@@ -392,7 +392,9 @@ func TestCacheExt_Cached_Common(t *testing.T) {
 	// nil
 	f_nil := func(_ context.Context, names []string, arg []int64) (interface{}, error) {
 		call_times += 1
-		return nil, nil
+		return func() (*string, error) {
+			return nil, nil
+		} ()
 	}
 	c_f_nil := cache.Cached("f_nil", f_nil, cachext.WithVersion(2), cachext.WithTTL(10*time.Second), cachext.WithCacheNil(false))
 	nil_res := ""
@@ -463,7 +465,7 @@ func TestCacheExt_Cached_Struct(t *testing.T) {
 		mydata.Value2 = "thre si a verty conplex data {}{}"
 		some_str := "some str"
 		mydata.Value4 = some_str
-		mydata.Value3 = []node{node{"这是第一个node", []string{"id1", "id2", "id3"}}, node{"这是第二个node", []string{"id4", "id5", "id6"}}}
+		mydata.Value3 = []node{{"这是第一个node", []string{"id1", "id2", "id3"}}, {"这是第二个node", []string{"id4", "id5", "id6"}}}
 		return mydata, nil
 	}
 	cached_complex_ff := cache.Cached("complex_ff", complex_ff, cachext.WithTTL(10*time.Second))


### PR DESCRIPTION
- 原来判断 `getResult` 的结果是否 nil 用的方式是 `res == nil`。但如果 res 储存的是带类型的 nil 指针，用 `res == nil` 得到的结果是 false，然后就不会走到 cacheNilHited 和 noNeedCacheNil 逻辑里，也永远不会返回 Nil
    - 就像单元测试 395 行的写法一样，实际使用时如果返回 nil，通常都是返回带指针类型的 nil
    - https://stackoverflow.com/questions/13476349/check-for-nil-and-nil-interface-in-go
- 所以原来 `GetResult` 必不可能返回 Nil
    - 我们的业务代码里用到缓存基本也都没有检查 err == cachext.Nil（即使可能返回 nil），也并没有出错。如果把这个改正确了，业务逻辑可能要动很多
- 这个 cachext 在最初写的时候目标之一就是不要用 reflect，但是现在要改成正确的逻辑只能加上 reflect

---

实测这样会返回 `false`：

https://goplay.tools/snippet/EL-F1YtXU98

![image](https://user-images.githubusercontent.com/10897528/144821189-3a570f36-86c0-4d0b-bdc1-c2484f3f8707.png)