### PR TITLE
rm cachenil

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 1.0.0 (2022-01-05)
+
+- 删除 cachext 的 cacheNil 逻辑
+
+**BREAKING CHANGE**:
+
+- 去掉 WithCacheNil 配置
+- 以前判断了 cachext.Nil 的地方，应该改为判断响应后 out 值是否为空值
+
 # 0.16.3 (2021-10-09)
 
 - 修正 `DialOptions` 拼写

--- a/extensions/cachext/ext.go
+++ b/extensions/cachext/ext.go
@@ -1,7 +1,6 @@
 package cachext
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -246,14 +245,6 @@ func encode(value interface{}) ([]byte, error) {
 
 func decode(data []byte, out interface{}) error {
 	return msgpack.Unmarshal(data, out)
-}
-
-func decodeIsNil(data interface{}) bool {
-	if byteData, ok := data.([]byte); ok {
-		err := msgpack.NewDecoder(bytes.NewReader(byteData)).DecodeNil()
-		return (err == nil)
-	}
-	return false
 }
 
 // Create a collector for total cache request counter


### PR DESCRIPTION
原来的 cachenil 逻辑有错误，会导致实际上只有一种情况会返回 cachext.Nil，即命中了 cache 且 cache 里存的是 msgpack nil 值；其他情况都不会。详见这里 https://github.com/shanbay/gobay/pull/363

---

如果改回正确的响应值，会和现状产生一个比较大的差异：改完了以后即使没有 WithCacheNil 同样可能返回 `cachext.Nil`。

而我们使用时都没有做过这个处理，改动起来会很大，所以干脆删除掉这个逻辑，让使用者在之前使用 WithCacheNil 的地方改为自行判断值是不是空值，这样改动会小得多。