### PR TITLE
Fix: config overwritten by default values

### DIFF
--- a/app.go
+++ b/app.go
@@ -166,7 +166,7 @@ func GetConfigByPrefix(config *viper.Viper, prefix string, trimPrefix bool) *vip
 		if trimPrefix {
 			key = k[len(prefix):]
 		}
-		subConfig.SetDefault(key, v)
+		subConfig.Set(key, v)
 	}
 	return subConfig
 }

--- a/extensions/busext/amqp.go
+++ b/extensions/busext/amqp.go
@@ -169,7 +169,7 @@ func (b *BusExt) Push(exchange, routingKey string, data amqp.Publishing) error {
 
 func (b *BusExt) doPush(ctx context.Context, exchange, routingKey string, data amqp.Publishing, result chan error) {
 	log.Printf("Trying to publish: %s\n", data.Headers["id"])
-	for i := 0; i <= b.publishRetry; i++ {
+	for i := 0; i < b.publishRetry; i++ {
 		// clear staled confirmnation
 		// 有可能在超时之后才收到 confirm，会堵塞 channel，最终造成死锁
 		select {

--- a/extensions/busext/amqp_test.go
+++ b/extensions/busext/amqp_test.go
@@ -72,6 +72,12 @@ func TestPushConsume(t *testing.T) {
 	time.Sleep(2 * time.Second)
 	assert.Len(t, result, 100)
 
+	// check config works
+	assert.NotEqual(t, defaultPublishRetry, bus.publishRetry)
+	assert.Equal(t, 5, bus.publishRetry)
+	assert.NotEqual(t, defaultPushTimeout, bus.pushTimeout)
+	assert.Equal(t, time.Second * 3, bus.pushTimeout)
+
 	// mock amqp 的 publish, 使其 sleep 一个远比设置的 pushTimeout 长的时间, 模拟其卡死的情况
 	bus.publishFunc = func(exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error {
 		dur := 100 * bus.pushTimeout

--- a/testdata/config.yaml
+++ b/testdata/config.yaml
@@ -7,7 +7,8 @@ defaults: &defaults
   bus_queues:
     - test
   bus_resend_delay: "1s"
-  bus_publish_retry: 3
+  bus_publish_retry: 5
+  bus_push_timeout: "3s"
   bus_prefetch: 10
   bus_quit_consumer_on_empty_queue: false
   bus_bindings:


### PR DESCRIPTION
### 背景
在测试busext时，发现config中传入的配置没有生效。其他ext如果在init时设置默认值，也有问题。

### 问题
`GetConfigByPrefix`中使用`subConfig.SetDefault( )`读取配置，给相应变量设置默认值之后，又会被extension初始化时设置的默认值替换掉。按照viper的配置优先级，读取配置应该直接`Set`，在ext初始化时，使用`SetDefault`。

![image](https://user-images.githubusercontent.com/16486368/184293109-1e6cd2a2-99d1-4f61-9c0a-f725c541435c.png)
