### PR TITLE
Feat/fix templates

### DIFF
--- a/cmd/gobay/templates/app/oapi/server.go.tmpl
+++ b/cmd/gobay/templates/app/oapi/server.go.tmpl
@@ -62,6 +62,7 @@ func Serve(
 	} else {
 		keepAlive = config.GetDuration("oapi_keep_alive")
 	}
+	e.Server.IdleTimeout = keepAlive
 
 	// Do something before start echo server
 	preStartFunc(e, app, enableAPM, true)
@@ -79,7 +80,6 @@ func Serve(
 	stopchan := make(chan os.Signal, 1)
 	signal.Notify(stopchan, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM)
 
-	e.Serve.IdleTimeout = keepAlive
 	go func(c <-chan os.Signal) {
 		<-c
 		err := e.Shutdown(context.Background())
@@ -166,7 +166,7 @@ func PreInitFunc(app *gobay.Application) {
 	myapp.InitExts(app)
 }
 
-func PreStartFunc func(e *echo.Echo, app *gobay.Application, enableAPM, enableDoc bool) {
+func PreStartFunc(e *echo.Echo, app *gobay.Application, enableAPM, enableDoc bool) {
 	impls := &{{ toLowerCamel $.Name }}Server{app: app}
 	configureMiddlewares(e, impls, enableAPM, enableDoc)
 }

--- a/cmd/gobay/templates/cmd/actions/oapisvc.go.tmpl
+++ b/cmd/gobay/templates/cmd/actions/oapisvc.go.tmpl
@@ -27,6 +27,7 @@ func RunOapiSvc(cmd *cobra.Command, args []string) {
 		bapp,
 		appoapi.PreInitFunc,
 		appoapi.PreStartFunc,
+		false,
 	); err != nil {
 		log.Fatalf("openapi serve failed: %v\n", err)
 	}

--- a/cmd/gobay/templates/go.mod.tmpl
+++ b/cmd/gobay/templates/go.mod.tmpl
@@ -7,4 +7,8 @@ require (
 	github.com/deepmap/oapi-codegen v1.12.4
 )
 
-replace entgo.io/ent => github.com/shanbay/ent v0.5.0
+replace (
+	entgo.io/ent => github.com/shanbay/ent v0.5.0
+	github.com/RichardKnop/machinery => github.com/shanbay/machinery v1.10.7-0.20210806005400-45afbf2ee694
+)
+

--- a/cmd/gobay/templates/go.mod.tmpl
+++ b/cmd/gobay/templates/go.mod.tmpl
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	entgo.io/ent v0.11.7
-	github.com/deepmap/oapi-codegen v1.8.2
+	github.com/deepmap/oapi-codegen v1.12.4
 )
 
-replace entgo.io/ent => github.com/shanbay/ent v0.11.7
+replace entgo.io/ent => github.com/shanbay/ent v0.5.0


### PR DESCRIPTION
1. 修复一些oapi模版中的语法错误
2. 修改deepmap/oapi-codegen版本为 v1.12.4。原来的v1.8.2 会导致  no matching operation was found
3. 默认向go mod中添加 RichardKnop/machinery replace，避免打包报错