### PR TITLE
feat: abstract redis

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 1.2.0
+# 1.2.1 (2024-5-17)
+
+- 新增 ISeqRedis 抽象执行 Lua 脚本，隐藏 go-redis 版本差异
+
+# 1.2.0 (2024-5-1)
 
 - 升级 go1.21
 - 添加用于执行定时任务的 CronJobExt
@@ -27,7 +31,7 @@
 
 - 改用 `shanbay/amqp`
 - 增加 asynctask ext 的健康检查
-    - 使用方法：`curl 127.0.0.1:9000/health?timeout=5&queue=gobay.task_sub`
+  - 使用方法：`curl 127.0.0.1:9000/health?timeout=5&queue=gobay.task_sub`
 
 # 0.14.0 (2020-11-19)
 

--- a/extensions/cachext/backend/redis/v9/redis.go
+++ b/extensions/cachext/backend/redis/v9/redis.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/redis/go-redis/v9"
 	"github.com/redis/go-redis/extra/redisotel/v9"
+	"github.com/redis/go-redis/v9"
 	"github.com/spf13/viper"
 	"go.opentelemetry.io/otel"
 
@@ -31,11 +31,11 @@ func (b *redisBackend) Init(config *viper.Viper) error {
 		Password: password,
 		DB:       dbNum,
 	})
+	b.client = redisClient
 	tp := otel.GetTracerProvider()
 	if err := redisotel.InstrumentTracing(redisClient, redisotel.WithTracerProvider(tp)); err != nil {
 		return err
 	}
-	b.client = redisClient
 	_, err := redisClient.Ping(context.Background()).Result()
 	return err
 }

--- a/extensions/redisext/ext.go
+++ b/extensions/redisext/ext.go
@@ -91,3 +91,8 @@ func (c *RedisExt) Application() *gobay.Application {
 func (c *RedisExt) Client(ctx context.Context) *redis.Client {
 	return c.redisclient.WithContext(ctx)
 }
+
+func (c *RedisExt) EvalLua(ctx context.Context, script string, keys []string, args ...any) (any, error) {
+	cmd := c.Client(ctx).Eval(script, keys, args...)
+	return cmd.Result()
+}

--- a/extensions/redisext/v9/ext.go
+++ b/extensions/redisext/v9/ext.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/redis/go-redis/extra/redisotel/v9"
 	"github.com/redis/go-redis/v9"
 	"github.com/shanbay/gobay"
-	"github.com/redis/go-redis/extra/redisotel/v9"
 	"go.opentelemetry.io/otel"
 )
 
@@ -98,4 +98,9 @@ func (c *RedisExt) Application() *gobay.Application {
 
 func (c *RedisExt) Client() *redis.Client {
 	return c.redisClient
+}
+
+func (c *RedisExt) EvalLua(ctx context.Context, script string, keys []string, args ...any) (any, error) {
+	cmd := c.redisClient.Eval(ctx, script, keys, args...)
+	return cmd.Result()
 }

--- a/go.mod
+++ b/go.mod
@@ -23,8 +23,8 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1
-	github.com/redis/go-redis/extra/redisotel/v9 v9.0.0-00010101000000-000000000000
-	github.com/redis/go-redis/v9 v9.5.1
+	github.com/redis/go-redis/extra/redisotel/v9 v9.0.5
+	github.com/redis/go-redis/v9 v9.5.2-0.20240510065232-0f0a28464c3d
 	github.com/satori/go.uuid v1.2.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -532,8 +532,8 @@ github.com/rabbitmq/amqp091-go v1.9.0 h1:qrQtyzB4H8BQgEuJwhmVQqVHB9O4+MNDJCCAcpc
 github.com/rabbitmq/amqp091-go v1.9.0/go.mod h1:+jPrT9iY2eLjRaMSRHUhc3z14E/l85kv/f+6luSD3pc=
 github.com/redis/go-redis/v9 v9.0.2/go.mod h1:/xDTe9EF1LM61hek62Poq2nzQSGj0xSrEtEHbBQevps=
 github.com/redis/go-redis/v9 v9.0.5/go.mod h1:WqMKv5vnQbRuZstUwxQI195wHy+t4PuXDOjzMvcuQHk=
-github.com/redis/go-redis/v9 v9.5.1 h1:H1X4D3yHPaYrkL5X06Wh6xNVM/pX0Ft4RV0vMGvLBh8=
-github.com/redis/go-redis/v9 v9.5.1/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0b/CLO2V2M=
+github.com/redis/go-redis/v9 v9.5.2-0.20240510065232-0f0a28464c3d h1:OqRnK3OgAzQZGhxAshrRDpdzkkKmYeltMQzbHsv6CQs=
+github.com/redis/go-redis/v9 v9.5.2-0.20240510065232-0f0a28464c3d/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0b/CLO2V2M=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=


### PR DESCRIPTION
因为有 `go-redis@v6` 和 `go-redis@v9` 共存，在使用到 `redis` 的 extension 内新增抽象隐藏不同 `go-redis` 版本上的差异