### PR TITLE
feat: config DisableErrSkip

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2.2 (2024-7-23)
+
+- 对 otelsql 设置 `DisableErrSkip: true` 以忽略 ErrSkip
+
 # 1.2.1 (2024-5-17)
 
 - 新增 ISeqRedis 抽象执行 Lua 脚本，隐藏 go-redis 版本差异

--- a/extensions/entext/ext.go
+++ b/extensions/entext/ext.go
@@ -56,6 +56,7 @@ func (d *EntExt) Init(app *gobay.Application) error {
 	if app.Config().GetBool("otel_enable") {
 		db, err = otelsql.Open(dbDriver, dbURL,
 			otelsql.WithSpanOptions(otelsql.SpanOptions{
+				DisableErrSkip: true,
 				SpanFilter: func(ctx context.Context, method otelsql.Method, query string, args []driver.NamedValue) bool {
 					return trace.SpanContextFromContext(ctx).IsValid()
 				}}),


### PR DESCRIPTION
带占位符的 SQL 执行流程为 prepared -> execute -> close 客户端将该语句和参数发给 mysql 编译成一个 prepared 语句，如果设置 `interpolateparams=true` 可以减少 prepared 请求，SQL 语句在客户端完成拼接。在 `go-sql-driver/mysql` 库中 如果发现没有设置该参数，会返回一个 `ErrSkip` 被 otelsql 捕捉，可以通过配置 `DisableErrSkip` 忽略这个报错，因为只是优化项不影响后续流程。但有实验表明 `interpolateparams=true` 能提高 QPS 18%，可以考虑在 DSN 中增加该参数
https://github.com/go-sql-driver/mysql/blob/f6a18cf1ac3e6bc282f72874a3742469a99e5762/connection.go#L327
