### PR TITLE
feat: remove shanbay/go-redis fork replace directives and upgrade go to 1.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v2
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.1.0
+        uses: golangci/golangci-lint-action@v6
         with:
           args: --timeout=10m --skip-dirs=testdata --tests=false
 
@@ -25,7 +27,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        go-version: ['1.21']
+        go-version: ['1.21', '1.24']
         os: [ubuntu-latest]
 
     services:
@@ -67,16 +69,16 @@ jobs:
       - name: Set up MySQL
         run: |
           mysql -e 'CREATE DATABASE ${{ env.DB_DATABASE }};' -u${{ env.DB_USER }} -p${{ env.DB_PASSWORD }} -h 127.0.0.1
-      - name: Check out code into Go module directory 
-        uses: actions/checkout@v2
+      - name: Check out code into Go module directory
+        uses: actions/checkout@v4
 
       - name: Set up golang ${{ matrix.go-version }}
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
-      
+
       - name: Go mod package cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: $GOPATH/pkg/mod
           key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - 移除 shanbay/go-redis fork 的 replace 指令，改用官方 `github.com/redis/go-redis/extra/redisotel/v9` v9.18.0 及 `rediscmd/v9` v9.18.0
 - 升级 go 版本至 1.24
+- CI 矩阵新增 Go 1.24，更新 actions 版本（checkout@v4、setup-go@v5、golangci-lint-action@v6、cache@v4）
 
 # 1.2.6 (2025-08-20)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.2.7 (2026-06-16)
+
+- 移除 shanbay/go-redis fork 的 replace 指令，改用官方 `github.com/redis/go-redis/extra/redisotel/v9` v9.18.0 及 `rediscmd/v9` v9.18.0
+- 升级 go 版本至 1.24
+
 # 1.2.6 (2025-08-20)
 
 - EntExt 新增 CheckHealth 方法

--- a/extensions/cachext/ext_test.go
+++ b/extensions/cachext/ext_test.go
@@ -402,7 +402,7 @@ func TestCacheExt_Cached_Common(t *testing.T) {
 	for i := 0; i <= 3; i++ {
 		err := c_f_nil.GetResult(context.Background(), &nil_res, []string{}, []int64{})
 		if err != nil || nil_res != "" {
-			t.Errorf(err.Error())
+			t.Error(err)
 		}
 	}
 	if call_times != 4 {
@@ -414,7 +414,7 @@ func TestCacheExt_Cached_Common(t *testing.T) {
 	for i := 0; i <= 3; i++ {
 		err := cn_f_nil.GetResult(context.Background(), &nil_res, []string{}, []int64{})
 		if err != nil || nil_res != "" {
-			t.Errorf(err.Error())
+			t.Error(err)
 		}
 	}
 	if call_times != 1 {

--- a/extensions/redisext/ext_test.go
+++ b/extensions/redisext/ext_test.go
@@ -25,7 +25,7 @@ func ExampleRedisExt_CheckHealth() {
 	// <nil>
 }
 
-func ExampleRedisExt_Set() {
+func ExampleRedisExt_Client() {
 	redis := &redisext.RedisExt{NS: "redis_"}
 	exts := map[gobay.Key]gobay.Extension{
 		"redis": redis,
@@ -60,7 +60,7 @@ func ExampleRedisExt_AddPrefix() {
 	// Output: github-redis.testRawKey
 }
 
-func ExampleRedisExt_AddPrefixNoPrefix() {
+func ExampleRedisExt_AddPrefix_noPrefix() {
 	redis := &redisext.RedisExt{NS: "redisnoprefix"}
 	exts := map[gobay.Key]gobay.Extension{
 		"redis": redis,

--- a/extensions/redisext/v9/ext_test.go
+++ b/extensions/redisext/v9/ext_test.go
@@ -26,7 +26,7 @@ func ExampleRedisExt_CheckHealth() {
 	// <nil>
 }
 
-func ExampleRedisExt_Set() {
+func ExampleRedisExt_Client() {
 	redis := &redisv9ext.RedisExt{NS: "redis_"}
 	exts := map[gobay.Key]gobay.Extension{
 		"redis": redis,
@@ -62,7 +62,7 @@ func ExampleRedisExt_AddPrefix() {
 	// Output: github-redis.testRawKey
 }
 
-func ExampleRedisExt_AddPrefixNoPrefix() {
+func ExampleRedisExt_AddPrefix_noPrefix() {
 	redis := &redisv9ext.RedisExt{NS: "redisnoprefix"}
 	exts := map[gobay.Key]gobay.Extension{
 		"redis": redis,

--- a/extensions/sentryext/custom_err/custom_err_message_test.go
+++ b/extensions/sentryext/custom_err/custom_err_message_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-func ExampleSentryExt_CaptureComplexError() {
+func Example_captureComplexError() {
 	var err = &CustomComplexError{
 		Message:  "This is a complex error",
 		MoreData: map[string]string{"key1": "val1", "key2": "val2"},
@@ -38,7 +38,7 @@ func Test_CaptureComplexError(t *testing.T) {
 		}
 	}()
 	if _, err := fixtureApp(); err != nil {
-		t.Errorf(err.Error())
+		t.Error(err)
 	}
 
 	var err = &CustomComplexError{

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shanbay/gobay
 
-go 1.21
+go 1.24
 
 require (
 	entgo.io/ent v0.11.7
@@ -23,8 +23,8 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.20.5
-	github.com/redis/go-redis/extra/redisotel/v9 v9.0.5
-	github.com/redis/go-redis/v9 v9.5.2-0.20240510065232-0f0a28464c3d
+	github.com/redis/go-redis/extra/redisotel/v9 v9.18.0
+	github.com/redis/go-redis/v9 v9.18.0
 	github.com/satori/go.uuid v1.2.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.7.1
@@ -118,7 +118,7 @@ require (
 	github.com/prometheus/common v0.60.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/rabbitmq/amqp091-go v1.9.0 // indirect
-	github.com/redis/go-redis/extra/rediscmd/v9 v9.5.1 // indirect
+	github.com/redis/go-redis/extra/rediscmd/v9 v9.18.0 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/santhosh-tekuri/jsonschema v1.2.4 // indirect
 	github.com/spf13/afero v1.1.2 // indirect
@@ -143,6 +143,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.29.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.26.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.2.0 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
 	golang.org/x/crypto v0.30.0 // indirect
 	golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 // indirect
 	golang.org/x/mod v0.17.0 // indirect
@@ -169,7 +170,5 @@ require (
 replace (
 	entgo.io/ent => github.com/shanbay/ent v0.5.0
 	github.com/RichardKnop/machinery => github.com/shanbay/machinery v0.0.0-20240507084232-78bfb8c2e7b1
-	github.com/redis/go-redis/extra/rediscmd/v9 => github.com/shanbay/go-redis/extra/rediscmd/v9 v9.0.0-20240507070244-b33c23f16a06
-	github.com/redis/go-redis/extra/redisotel/v9 => github.com/shanbay/go-redis/extra/redisotel/v9 v9.0.0-20240507070244-b33c23f16a06
 	github.com/streadway/amqp => github.com/shanbay/amqp v1.0.1-0.20210728052407-b63250c049f2
 )

--- a/go.sum
+++ b/go.sum
@@ -452,6 +452,8 @@ github.com/klauspost/compress v1.11.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYs
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
 github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
+github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
+github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
@@ -579,10 +581,14 @@ github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoG
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rabbitmq/amqp091-go v1.9.0 h1:qrQtyzB4H8BQgEuJwhmVQqVHB9O4+MNDJCCAcpc3Aoo=
 github.com/rabbitmq/amqp091-go v1.9.0/go.mod h1:+jPrT9iY2eLjRaMSRHUhc3z14E/l85kv/f+6luSD3pc=
+github.com/redis/go-redis/extra/rediscmd/v9 v9.18.0 h1:QY4nmPHLFAJjtT5O4OMUEOxP8WVaRNOFpcbmxT2NLZU=
+github.com/redis/go-redis/extra/rediscmd/v9 v9.18.0/go.mod h1:WH8cY/0fT41Bsf341qzo8v4nx0GCE8FykAA23IVbVmo=
+github.com/redis/go-redis/extra/redisotel/v9 v9.18.0 h1:2dKdoEYBJ0CZCLPiCdvvc7luz3DPwY6hKdzjL6m1eHE=
+github.com/redis/go-redis/extra/redisotel/v9 v9.18.0/go.mod h1:WzkrVG9ro9BwCQD0eJOWn6AGL4Z1CleGflM45w1hu10=
 github.com/redis/go-redis/v9 v9.0.2/go.mod h1:/xDTe9EF1LM61hek62Poq2nzQSGj0xSrEtEHbBQevps=
 github.com/redis/go-redis/v9 v9.0.5/go.mod h1:WqMKv5vnQbRuZstUwxQI195wHy+t4PuXDOjzMvcuQHk=
-github.com/redis/go-redis/v9 v9.5.2-0.20240510065232-0f0a28464c3d h1:OqRnK3OgAzQZGhxAshrRDpdzkkKmYeltMQzbHsv6CQs=
-github.com/redis/go-redis/v9 v9.5.2-0.20240510065232-0f0a28464c3d/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0b/CLO2V2M=
+github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
+github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
@@ -608,10 +614,6 @@ github.com/shanbay/amqp v1.0.1-0.20210728052407-b63250c049f2 h1:fc3CZIsyZTW2mfv+
 github.com/shanbay/amqp v1.0.1-0.20210728052407-b63250c049f2/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/shanbay/ent v0.5.0 h1:J/QSzM14R+gxlhPdaqm2uFs3Y446xdpIzLYavGLRMvo=
 github.com/shanbay/ent v0.5.0/go.mod h1:ericBi6Q8l3wBH1wEIDfKxw7rcQEuRPyBfbIzjtxJ18=
-github.com/shanbay/go-redis/extra/rediscmd/v9 v9.0.0-20240507070244-b33c23f16a06 h1:/6w+WdQczhGDqpYLT9aAaY1+dMNW3UaZuFB6tJaVMJA=
-github.com/shanbay/go-redis/extra/rediscmd/v9 v9.0.0-20240507070244-b33c23f16a06/go.mod h1:SGzPYn+57aRi8pgnS/IauR64lWhJhgWqIZH6IIfgEBU=
-github.com/shanbay/go-redis/extra/redisotel/v9 v9.0.0-20240507070244-b33c23f16a06 h1:Uf/Nfgp5ysKE3WPc2/rGfpMkXJRUsIAE6RhrZFtmlwk=
-github.com/shanbay/go-redis/extra/redisotel/v9 v9.0.0-20240507070244-b33c23f16a06/go.mod h1:INDsEOD4QyPk6Pm4JXWZvuDiChhtZa7PN60RSXljsbc=
 github.com/shanbay/machinery v0.0.0-20240507084232-78bfb8c2e7b1 h1:xKAZ1T41qkL2ruX/2VcIrWqRaXljH/SdrYpT2s3s/ec=
 github.com/shanbay/machinery v0.0.0-20240507084232-78bfb8c2e7b1/go.mod h1:oJibs3otH55CKsd/2rOpgLAHlDG9FQy2/+zMkZlR8VY=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
@@ -695,6 +697,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zclconf/go-cty v1.8.0 h1:s4AvqaeQzJIu3ndv4gVIhplVD0krU+bgrcLSVUnaWuA=
 github.com/zclconf/go-cty v1.8.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
+github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
+github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 go.einride.tech/aip v0.68.0 h1:4seM66oLzTpz50u4K1zlJyOXQ3tCzcJN7I22tKkjipw=
 go.einride.tech/aip v0.68.0/go.mod h1:7y9FF8VtPWqpxuAxl0KQWqaULxW4zFIesD6zF5RIHHg=
@@ -748,6 +752,8 @@ go.opentelemetry.io/proto/otlp v1.2.0/go.mod h1:gGpR8txAl5M03pDhMC79G6SdqNV26naR
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
+go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
+go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=


### PR DESCRIPTION
  ## Summary

  - 移除针对 shanbay/go-redis fork 的两条 replace 指令（redisotel/v9 和 rediscmd/v9）
  - 官方包 github.com/redis/go-redis/extra/redisotel/v9 现已在 Go module proxy 上独立发布，无需 fork
  - redisotel/v9 从 v9.0.5 升级至 v9.18.0，go-redis/v9 随之升至 v9.18.0
  - go directive 从 1.21 升至 1.24

  ## Background

  2024 年 4 月（commit 40adfec）引入 shanbay/go-redis fork，原因是 go-redis 子模块内部有相对路径 replace 指令导致消费方无法直接引用。Go module proxy 在分发时会剥离这些 replace 指令，现在官方包已有正式
  tag（v9.18.0），可以独立消费，不再需要 fork。

  ## Test plan
  - [x] go build ./... 通过
  - [x] go mod tidy 干净，无额外 replace
  - [x] redis 相关 ext 集成测试：go test ./extensions/redisext/... ./extensions/cachext/...