### PR TITLE
feat: asynctaskext/busext 增加 Prometheus 处理耗时+QPS 埋点（与 coast 同契约）

### DIFF
--- a/extensions/asynctaskext/asynctaskext.go
+++ b/extensions/asynctaskext/asynctaskext.go
@@ -30,18 +30,15 @@ const (
 )
 
 type AsyncTaskExt struct {
-	NS string
-	// MetricsServerAddr 为 /metrics 监听地址，空值时使用 DefaultMetricsServerAddr(:9808)
-	MetricsServerAddr string
-	app               *gobay.Application
-	config            *machineryConfig.Config
-	server            *machinery.Server
-	workers           []*machinery.Worker
+	NS      string
+	app     *gobay.Application
+	config  *machineryConfig.Config
+	server  *machinery.Server
+	workers []*machinery.Worker
 
 	lock                    sync.Mutex
 	healthCheckCompleteChan chan string
 	healthHandlerRegistered bool
-	metricsServerStarted    bool
 }
 
 func (t *AsyncTaskExt) Object() interface{} {
@@ -108,9 +105,6 @@ func (t *AsyncTaskExt) StartWorker(queue string, concurrency int, enableHealthCh
 	worker := t.server.NewWorker(tag, concurrency)
 	worker.Queue = queue
 	t.workers = append(t.workers, worker)
-
-	// run prometheus metrics http server
-	t.startMetricsServer()
 
 	// run health check http server
 	if enableHealthCheck && !t.healthHandlerRegistered {

--- a/extensions/asynctaskext/asynctaskext.go
+++ b/extensions/asynctaskext/asynctaskext.go
@@ -30,15 +30,18 @@ const (
 )
 
 type AsyncTaskExt struct {
-	NS      string
-	app     *gobay.Application
-	config  *machineryConfig.Config
-	server  *machinery.Server
-	workers []*machinery.Worker
+	NS string
+	// MetricsServerAddr 为 /metrics 监听地址，空值时使用 DefaultMetricsServerAddr(:9808)
+	MetricsServerAddr string
+	app               *gobay.Application
+	config            *machineryConfig.Config
+	server            *machinery.Server
+	workers           []*machinery.Worker
 
 	lock                    sync.Mutex
 	healthCheckCompleteChan chan string
 	healthHandlerRegistered bool
+	metricsServerStarted    bool
 }
 
 func (t *AsyncTaskExt) Object() interface{} {
@@ -82,12 +85,16 @@ func (t *AsyncTaskExt) Close() error {
 
 //RegisterWorkerHandler add task handler to worker to process task messages
 func (t *AsyncTaskExt) RegisterWorkerHandler(name string, handler interface{}) error {
-	return t.server.RegisterTask(name, handler)
+	return t.server.RegisterTask(name, t.wrapTaskHandler(name, handler))
 }
 
 //RegisterWorkerHandlers add task handlers to worker to process task messages
 func (t *AsyncTaskExt) RegisterWorkerHandlers(handlers map[string]interface{}) error {
-	return t.server.RegisterTasks(handlers)
+	wrapped := make(map[string]interface{}, len(handlers))
+	for name, handler := range handlers {
+		wrapped[name] = t.wrapTaskHandler(name, handler)
+	}
+	return t.server.RegisterTasks(wrapped)
 }
 
 //StartWorker start a worker that consume task messages for queue
@@ -101,6 +108,9 @@ func (t *AsyncTaskExt) StartWorker(queue string, concurrency int, enableHealthCh
 	worker := t.server.NewWorker(tag, concurrency)
 	worker.Queue = queue
 	t.workers = append(t.workers, worker)
+
+	// run prometheus metrics http server
+	t.startMetricsServer()
 
 	// run health check http server
 	if enableHealthCheck && !t.healthHandlerRegistered {

--- a/extensions/asynctaskext/metrics.go
+++ b/extensions/asynctaskext/metrics.go
@@ -1,0 +1,122 @@
+package asynctaskext
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"reflect"
+	"time"
+
+	"github.com/RichardKnop/machinery/v1/log"
+	"github.com/RichardKnop/machinery/v1/tasks"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// DefaultMetricsServerAddr 与 Python 中间件 coast 的 AsyncTask(9808) 保持一致，
+// 方便两种语言的 worker 共用同一套 scrape 配置。
+const DefaultMetricsServerAddr = ":9808"
+
+// taskDurationBuckets 必须与 coast 的 _TASK_DURATION_BUCKETS 逐档一致，
+// 否则跨语言 histogram_quantile 合并查询会得到错误的分位数。
+var taskDurationBuckets = []float64{0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600}
+
+// asyncTaskDurationSeconds 与 coast 的同名指标做跨语言合并查询。
+// label 语义对齐 coast：task_name=注册名；queue=signature 的 RoutingKey（≈消费队列）；
+// status=success/failure/retry。
+var asyncTaskDurationSeconds = promauto.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Name:    "asynctask_task_duration_seconds",
+		Help:    "Time spent processing an asynctask message",
+		Buckets: taskDurationBuckets,
+	},
+	[]string{"task_name", "queue", "status"},
+)
+
+var ctxType = reflect.TypeOf((*context.Context)(nil)).Elem()
+
+// wrapTaskHandler 用反射包装业务 handler，记录执行耗时与状态，保持函数签名不变。
+// handler 首参为 context.Context 时从 signature 取 RoutingKey 作为 queue label，
+// 否则回退到配置的 DefaultQueue。
+func (t *AsyncTaskExt) wrapTaskHandler(name string, handler interface{}) interface{} {
+	hv := reflect.ValueOf(handler)
+	ht := hv.Type()
+	if ht.Kind() != reflect.Func {
+		// 非法 handler 原样返回，由 machinery 的注册校验负责报错
+		return handler
+	}
+	hasCtx := ht.NumIn() > 0 && ht.In(0) == ctxType
+	isVariadic := ht.IsVariadic()
+	return reflect.MakeFunc(ht, func(args []reflect.Value) []reflect.Value {
+		queue := ""
+		if t.config != nil {
+			queue = t.config.DefaultQueue
+		}
+		if hasCtx && len(args) > 0 {
+			if ctx, ok := args[0].Interface().(context.Context); ok {
+				if sig := tasks.SignatureFromContext(ctx); sig != nil && sig.RoutingKey != "" {
+					queue = sig.RoutingKey
+				}
+			}
+		}
+		if queue == "" {
+			queue = "unknown"
+		}
+		start := time.Now()
+		// MakeFunc 的内层函数收到的变参已被收集为 slice，回调原函数必须用 CallSlice
+		var results []reflect.Value
+		if isVariadic {
+			results = hv.CallSlice(args)
+		} else {
+			results = hv.Call(args)
+		}
+		asyncTaskDurationSeconds.WithLabelValues(name, queue, taskStatus(results)).
+			Observe(time.Since(start).Seconds())
+		return results
+	}).Interface()
+}
+
+// taskStatus 从 handler 返回值判断任务状态。machinery 约定最后一个返回值为 error：
+// nil → success；ErrRetryTaskLater → retry（对齐 celery 的 RETRY state）；其余 → failure。
+func taskStatus(results []reflect.Value) string {
+	n := len(results)
+	if n == 0 {
+		return "success"
+	}
+	last := results[n-1]
+	if last.Kind() != reflect.Interface || last.IsNil() {
+		return "success"
+	}
+	err, ok := last.Interface().(error)
+	if !ok || err == nil {
+		return "success"
+	}
+	var retryErr tasks.ErrRetryTaskLater
+	if errors.As(err, &retryErr) {
+		return "retry"
+	}
+	return "failure"
+}
+
+// startMetricsServer 在 worker 进程内暴露 /metrics（默认 :9808）。
+// 端口被占等启动失败仅记录日志，不影响 worker 消费（与 coast 行为一致）。
+// 调用方需持有 t.lock。
+func (t *AsyncTaskExt) startMetricsServer() {
+	if t.metricsServerStarted {
+		return
+	}
+	t.metricsServerStarted = true
+	addr := t.MetricsServerAddr
+	if addr == "" {
+		addr = DefaultMetricsServerAddr
+	}
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	srv := &http.Server{Addr: addr, Handler: mux}
+	go func() {
+		if err := srv.ListenAndServe(); err != nil {
+			log.WARNING.Printf("asynctask metrics server not started: %v\n", err)
+		}
+	}()
+}

--- a/extensions/asynctaskext/metrics.go
+++ b/extensions/asynctaskext/metrics.go
@@ -3,20 +3,13 @@ package asynctaskext
 import (
 	"context"
 	"errors"
-	"net/http"
 	"reflect"
 	"time"
 
-	"github.com/RichardKnop/machinery/v1/log"
 	"github.com/RichardKnop/machinery/v1/tasks"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
-
-// DefaultMetricsServerAddr 与 Python 中间件 coast 的 AsyncTask(9808) 保持一致，
-// 方便两种语言的 worker 共用同一套 scrape 配置。
-const DefaultMetricsServerAddr = ":9808"
 
 // taskDurationBuckets 必须与 coast 的 _TASK_DURATION_BUCKETS 逐档一致，
 // 否则跨语言 histogram_quantile 合并查询会得到错误的分位数。
@@ -99,24 +92,3 @@ func taskStatus(results []reflect.Value) string {
 	return "failure"
 }
 
-// startMetricsServer 在 worker 进程内暴露 /metrics（默认 :9808）。
-// 端口被占等启动失败仅记录日志，不影响 worker 消费（与 coast 行为一致）。
-// 调用方需持有 t.lock。
-func (t *AsyncTaskExt) startMetricsServer() {
-	if t.metricsServerStarted {
-		return
-	}
-	t.metricsServerStarted = true
-	addr := t.MetricsServerAddr
-	if addr == "" {
-		addr = DefaultMetricsServerAddr
-	}
-	mux := http.NewServeMux()
-	mux.Handle("/metrics", promhttp.Handler())
-	srv := &http.Server{Addr: addr, Handler: mux}
-	go func() {
-		if err := srv.ListenAndServe(); err != nil {
-			log.WARNING.Printf("asynctask metrics server not started: %v\n", err)
-		}
-	}()
-}

--- a/extensions/asynctaskext/metrics_test.go
+++ b/extensions/asynctaskext/metrics_test.go
@@ -1,0 +1,164 @@
+package asynctaskext
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	machineryConfig "github.com/RichardKnop/machinery/v1/config"
+	"github.com/RichardKnop/machinery/v1/tasks"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+)
+
+// asyncTaskHistSample 读取指定 label 组合当前的 count/sum，从未 observe 过时为 (0, 0)。
+func asyncTaskHistSample(t *testing.T, taskName, queue, status string) (uint64, float64) {
+	t.Helper()
+	obs, err := asyncTaskDurationSeconds.GetMetricWithLabelValues(taskName, queue, status)
+	assert.Nil(t, err)
+	m := &dto.Metric{}
+	assert.Nil(t, obs.(prometheus.Metric).Write(m))
+	return m.GetHistogram().GetSampleCount(), m.GetHistogram().GetSampleSum()
+}
+
+func metricsTestExt() *AsyncTaskExt {
+	return &AsyncTaskExt{
+		NS:     "asynctask_",
+		config: &machineryConfig.Config{DefaultQueue: "gobay.task"},
+	}
+}
+
+// 无 ctx handler：queue 回退到 DefaultQueue；nil error → success；耗时被记录
+func TestWrapTaskHandlerSuccessWithDefaultQueue(t *testing.T) {
+	ext := metricsTestExt()
+	name := fmt.Sprintf("metrics.ok.%d", time.Now().UnixNano())
+
+	wrapped := ext.wrapTaskHandler(name, func() error {
+		time.Sleep(5 * time.Millisecond)
+		return nil
+	})
+	task, err := tasks.New(wrapped, []tasks.Arg{})
+	assert.Nil(t, err)
+	_, err = task.Call()
+	assert.Nil(t, err)
+
+	count, sum := asyncTaskHistSample(t, name, "gobay.task", "success")
+	assert.Equal(t, uint64(1), count)
+	assert.GreaterOrEqual(t, sum, 0.005)
+}
+
+// ctx handler：queue 取 signature 的 RoutingKey
+func TestWrapTaskHandlerQueueFromSignatureRoutingKey(t *testing.T) {
+	ext := metricsTestExt()
+	name := fmt.Sprintf("metrics.ctx.%d", time.Now().UnixNano())
+
+	wrapped := ext.wrapTaskHandler(name, func(ctx context.Context) error {
+		return nil
+	})
+	sig := &tasks.Signature{Name: name, RoutingKey: "gobay.task_sub"}
+	task, err := tasks.NewWithSignature(wrapped, sig)
+	assert.Nil(t, err)
+	_, err = task.Call()
+	assert.Nil(t, err)
+
+	count, _ := asyncTaskHistSample(t, name, "gobay.task_sub", "success")
+	assert.Equal(t, uint64(1), count)
+	// DefaultQueue 组合不应被记录
+	fallbackCount, _ := asyncTaskHistSample(t, name, "gobay.task", "success")
+	assert.Equal(t, uint64(0), fallbackCount)
+}
+
+// handler 返回普通 error → status=failure
+func TestWrapTaskHandlerFailure(t *testing.T) {
+	ext := metricsTestExt()
+	name := fmt.Sprintf("metrics.fail.%d", time.Now().UnixNano())
+
+	wrapped := ext.wrapTaskHandler(name, func() error {
+		return errors.New("boom")
+	})
+	task, err := tasks.New(wrapped, []tasks.Arg{})
+	assert.Nil(t, err)
+	_, err = task.Call()
+	assert.NotNil(t, err)
+
+	count, _ := asyncTaskHistSample(t, name, "gobay.task", "failure")
+	assert.Equal(t, uint64(1), count)
+}
+
+// handler 返回 ErrRetryTaskLater → status=retry（对齐 celery RETRY state）
+func TestWrapTaskHandlerRetry(t *testing.T) {
+	ext := metricsTestExt()
+	name := fmt.Sprintf("metrics.retry.%d", time.Now().UnixNano())
+
+	wrapped := ext.wrapTaskHandler(name, func() error {
+		return tasks.NewErrRetryTaskLater("try again", time.Second)
+	})
+	task, err := tasks.New(wrapped, []tasks.Arg{})
+	assert.Nil(t, err)
+	_, _ = task.Call()
+
+	count, _ := asyncTaskHistSample(t, name, "gobay.task", "retry")
+	assert.Equal(t, uint64(1), count)
+	failureCount, _ := asyncTaskHistSample(t, name, "gobay.task", "failure")
+	assert.Equal(t, uint64(0), failureCount)
+}
+
+// 包装不改变 handler 的参数与返回值传递
+func TestWrapTaskHandlerPreservesArgsAndResults(t *testing.T) {
+	ext := metricsTestExt()
+	name := fmt.Sprintf("metrics.args.%d", time.Now().UnixNano())
+
+	wrapped := ext.wrapTaskHandler(name, func(a, b int64) (int64, error) {
+		return a + b, nil
+	})
+	task, err := tasks.New(wrapped, []tasks.Arg{
+		{Type: "int64", Value: int64(1)},
+		{Type: "int64", Value: int64(2)},
+	})
+	assert.Nil(t, err)
+	results, err := task.Call()
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(results))
+	assert.Equal(t, "3", fmt.Sprintf("%v", results[0].Value))
+}
+
+// 变参 handler（TaskAdd 形态）：MakeFunc 收集的变参必须经 CallSlice 正确还原
+func TestWrapTaskHandlerVariadic(t *testing.T) {
+	ext := metricsTestExt()
+	name := fmt.Sprintf("metrics.variadic.%d", time.Now().UnixNano())
+
+	wrapped := ext.wrapTaskHandler(name, func(args ...int64) (int64, error) {
+		sum := int64(0)
+		for _, arg := range args {
+			sum += arg
+		}
+		return sum, nil
+	})
+	task, err := tasks.New(wrapped, []tasks.Arg{
+		{Type: "int64", Value: int64(1)},
+		{Type: "int64", Value: int64(2)},
+		{Type: "int64", Value: int64(3)},
+	})
+	assert.Nil(t, err)
+	results, err := task.Call()
+	assert.Nil(t, err)
+	assert.Equal(t, "6", fmt.Sprintf("%v", results[0].Value))
+
+	count, _ := asyncTaskHistSample(t, name, "gobay.task", "success")
+	assert.Equal(t, uint64(1), count)
+}
+
+// 指标元数据：名称/label/bucket 与 coast 契约一致
+func TestAsyncTaskHistogramMetadata(t *testing.T) {
+	obs, err := asyncTaskDurationSeconds.GetMetricWithLabelValues("meta.check", "q", "success")
+	assert.Nil(t, err)
+	m := &dto.Metric{}
+	assert.Nil(t, obs.(prometheus.Metric).Write(m))
+	// 13 档显式 bucket（+Inf 不出现在 dto 中）
+	assert.Equal(t, 13, len(m.GetHistogram().GetBucket()))
+	assert.Equal(t, 0.05, m.GetHistogram().GetBucket()[0].GetUpperBound())
+	assert.Equal(t, float64(600), m.GetHistogram().GetBucket()[12].GetUpperBound())
+}

--- a/extensions/busext/amqp.go
+++ b/extensions/busext/amqp.go
@@ -70,8 +70,6 @@ type BusExt struct {
 	publishFunc     func(exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error
 	brokerUrl       string
 	notifyChanBlock chan error
-
-	metricsServerStarted bool
 }
 
 func (b *BusExt) Object() interface{} {
@@ -243,8 +241,6 @@ func (b *BusExt) Consume() error {
 		b.ErrorLogger.Println("can not consume. BusExt is not ready")
 		return errNotConnected
 	}
-	// run prometheus metrics http server
-	b.startMetricsServer()
 	if err := b.channel.Qos(b.prefetch, 0, false); err != nil {
 		b.ErrorLogger.Printf("set qos failed: %v\n", err)
 	}

--- a/extensions/busext/amqp.go
+++ b/extensions/busext/amqp.go
@@ -42,8 +42,10 @@ type customLoggerInterface interface {
 }
 
 type BusExt struct {
-	NS              string
-	app             *gobay.Application
+	NS string
+	// MetricsServerAddr 为 /metrics 监听地址，空值时使用 DefaultMetricsServerAddr(:9809)
+	MetricsServerAddr string
+	app               *gobay.Application
 	connection      *amqp.Connection
 	channel         *amqp.Channel
 	done            chan bool
@@ -68,6 +70,8 @@ type BusExt struct {
 	publishFunc     func(exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error
 	brokerUrl       string
 	notifyChanBlock chan error
+
+	metricsServerStarted bool
 }
 
 func (b *BusExt) Object() interface{} {
@@ -239,6 +243,8 @@ func (b *BusExt) Consume() error {
 		b.ErrorLogger.Println("can not consume. BusExt is not ready")
 		return errNotConnected
 	}
+	// run prometheus metrics http server
+	b.startMetricsServer()
 	if err := b.channel.Qos(b.prefetch, 0, false); err != nil {
 		b.ErrorLogger.Printf("set qos failed: %v\n", err)
 	}
@@ -294,8 +300,13 @@ func (b *BusExt) Consume() error {
 						} else if err := handler.ParsePayload(payload[0],
 							payload[1]); err != nil {
 							b.ErrorLogger.Printf("handler parse payload error: %v\n", err)
-						} else if err := handler.Run(); err != nil {
-							b.ErrorLogger.Printf("handler run task failed: %v\n", err)
+						} else {
+							start := time.Now()
+							err := handler.Run()
+							observeBusTask(delivery.RoutingKey, start, err)
+							if err != nil {
+								b.ErrorLogger.Printf("handler run task failed: %v\n", err)
+							}
 						}
 					}
 				}

--- a/extensions/busext/metrics.go
+++ b/extensions/busext/metrics.go
@@ -1,0 +1,61 @@
+package busext
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// DefaultMetricsServerAddr 与 Python 中间件 coast 的 Bus(9809) 保持一致，
+// 方便两种语言的 worker 共用同一套 scrape 配置。
+const DefaultMetricsServerAddr = ":9809"
+
+// taskDurationBuckets 必须与 coast 的 _TASK_DURATION_BUCKETS 逐档一致，
+// 否则跨语言 histogram_quantile 合并查询会得到错误的分位数。
+var taskDurationBuckets = []float64{0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600}
+
+// busTaskDurationSeconds 与 coast 的同名指标做跨语言合并查询。
+// label 语义对齐 coast：task_name 与 queue 均取消息的 routing key
+// （celery 协议下 bus 消息的 routing key 即任务名）；status=success/failure。
+var busTaskDurationSeconds = promauto.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Name:    "bus_task_duration_seconds",
+		Help:    "Time spent processing a bus message",
+		Buckets: taskDurationBuckets,
+	},
+	[]string{"task_name", "queue", "status"},
+)
+
+// observeBusTask 记录一次 bus 消息处理的耗时与状态。
+func observeBusTask(routingKey string, start time.Time, err error) {
+	status := "success"
+	if err != nil {
+		status = "failure"
+	}
+	busTaskDurationSeconds.WithLabelValues(routingKey, routingKey, status).
+		Observe(time.Since(start).Seconds())
+}
+
+// startMetricsServer 在消费进程内暴露 /metrics（默认 :9809）。
+// 端口被占等启动失败仅记录日志，不影响消费（与 coast 行为一致）。
+func (b *BusExt) startMetricsServer() {
+	if b.metricsServerStarted {
+		return
+	}
+	b.metricsServerStarted = true
+	addr := b.MetricsServerAddr
+	if addr == "" {
+		addr = DefaultMetricsServerAddr
+	}
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	srv := &http.Server{Addr: addr, Handler: mux}
+	go func() {
+		if err := srv.ListenAndServe(); err != nil {
+			b.ErrorLogger.Printf("bus metrics server not started: %v\n", err)
+		}
+	}()
+}

--- a/extensions/busext/metrics.go
+++ b/extensions/busext/metrics.go
@@ -1,17 +1,11 @@
 package busext
 
 import (
-	"net/http"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
-
-// DefaultMetricsServerAddr 与 Python 中间件 coast 的 Bus(9809) 保持一致，
-// 方便两种语言的 worker 共用同一套 scrape 配置。
-const DefaultMetricsServerAddr = ":9809"
 
 // taskDurationBuckets 必须与 coast 的 _TASK_DURATION_BUCKETS 逐档一致，
 // 否则跨语言 histogram_quantile 合并查询会得到错误的分位数。
@@ -39,23 +33,3 @@ func observeBusTask(routingKey string, start time.Time, err error) {
 		Observe(time.Since(start).Seconds())
 }
 
-// startMetricsServer 在消费进程内暴露 /metrics（默认 :9809）。
-// 端口被占等启动失败仅记录日志，不影响消费（与 coast 行为一致）。
-func (b *BusExt) startMetricsServer() {
-	if b.metricsServerStarted {
-		return
-	}
-	b.metricsServerStarted = true
-	addr := b.MetricsServerAddr
-	if addr == "" {
-		addr = DefaultMetricsServerAddr
-	}
-	mux := http.NewServeMux()
-	mux.Handle("/metrics", promhttp.Handler())
-	srv := &http.Server{Addr: addr, Handler: mux}
-	go func() {
-		if err := srv.ListenAndServe(); err != nil {
-			b.ErrorLogger.Printf("bus metrics server not started: %v\n", err)
-		}
-	}()
-}

--- a/extensions/busext/metrics_test.go
+++ b/extensions/busext/metrics_test.go
@@ -1,0 +1,56 @@
+package busext
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+)
+
+// busHistSample 读取指定 label 组合当前的 count/sum，从未 observe 过时为 (0, 0)。
+func busHistSample(t *testing.T, taskName, queue, status string) (uint64, float64) {
+	t.Helper()
+	obs, err := busTaskDurationSeconds.GetMetricWithLabelValues(taskName, queue, status)
+	assert.Nil(t, err)
+	m := &dto.Metric{}
+	assert.Nil(t, obs.(prometheus.Metric).Write(m))
+	return m.GetHistogram().GetSampleCount(), m.GetHistogram().GetSampleSum()
+}
+
+// 成功路径：status=success，task_name 与 queue 均为 routing key，耗时被记录
+func TestObserveBusTaskSuccess(t *testing.T) {
+	routingKey := fmt.Sprintf("buses.metrics.ok.%d", time.Now().UnixNano())
+
+	observeBusTask(routingKey, time.Now().Add(-10*time.Millisecond), nil)
+
+	count, sum := busHistSample(t, routingKey, routingKey, "success")
+	assert.Equal(t, uint64(1), count)
+	assert.GreaterOrEqual(t, sum, 0.01)
+}
+
+// 失败路径：handler 返回 error → status=failure
+func TestObserveBusTaskFailure(t *testing.T) {
+	routingKey := fmt.Sprintf("buses.metrics.fail.%d", time.Now().UnixNano())
+
+	observeBusTask(routingKey, time.Now(), errors.New("boom"))
+
+	count, _ := busHistSample(t, routingKey, routingKey, "failure")
+	assert.Equal(t, uint64(1), count)
+	successCount, _ := busHistSample(t, routingKey, routingKey, "success")
+	assert.Equal(t, uint64(0), successCount)
+}
+
+// 指标元数据：名称/label/bucket 与 coast 契约一致
+func TestBusHistogramMetadata(t *testing.T) {
+	obs, err := busTaskDurationSeconds.GetMetricWithLabelValues("meta.check", "q", "success")
+	assert.Nil(t, err)
+	m := &dto.Metric{}
+	assert.Nil(t, obs.(prometheus.Metric).Write(m))
+	assert.Equal(t, 13, len(m.GetHistogram().GetBucket()))
+	assert.Equal(t, 0.05, m.GetHistogram().GetBucket()[0].GetUpperBound())
+	assert.Equal(t, float64(600), m.GetHistogram().GetBucket()[12].GetUpperBound())
+}


### PR DESCRIPTION
## Summary

为 asynctaskext / busext 增加两个 Prometheus Histogram，与 Python 中间件 coast 102.0.10（backend-lib/coast!240）**同名同契约**，跨语言合并查询时 Grafana/PromQL 不需要区分 Go/Python 服务：

| 指标 | 挂点 |
|---|---|
| `asynctask_task_duration_seconds` | `RegisterWorkerHandler(s)` 反射包装业务 handler |
| `bus_task_duration_seconds` | `Consume()` 循环包裹 `handler.Run()` |

**契约（与 coast 逐项一致，改动任何一项需两边同步）：**
- label：`task_name / queue / status`
- bucket：`0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600`（跨语言 `histogram_quantile` 合并要求逐档一致）
- status 词表：`success / failure / retry`
- queue 语义：取消息 routing key（asynctask 取 signature `RoutingKey` ≈ 消费队列；bus 上 celery 协议 routing key 即任务名，与 coast 行为一致）

## 指标暴露：复用既有 :9000 惯例，不新开端口

指标注册在**默认 registry**。生产上 Go 服务（含多个 asynctask/bus worker，如 words 组的 math-learning）已统一在 `:9000` 经 promhttp 暴露并被 `prometheus.io/port: 9000` 注解抓取——本 PR 的指标会**自动出现在这些既有端点**，升级即接入，零新端口零新配置。尚无 metrics server 的 worker 服务按既有惯例在应用侧补 `:9000` promhttp 即可。（coast 的 9808/9809 保留为 Python worker 专属约定，Python worker 进程内没有现成 HTTP server。）

## 实现要点

- **asynctask status**：machinery 的 post hook 不带 error，故在注册时用 `reflect.MakeFunc` 包装 handler，从最后一个返回值判定（`nil`=success、`ErrRetryTaskLater`=retry、其余=failure）；变参 handler 经 `CallSlice` 还原（已被存量 `TaskAdd` 测试覆盖）
- **queue label**：handler 首参为 `context.Context` 时经 `tasks.SignatureFromContext` 取 `RoutingKey`，否则回退配置的 `DefaultQueue`
- gobay 内置 health check 任务不计入指标
- 已知差异：普通 error + `RetryCount>0` 的 machinery 重试路径记为 `failure`（celery 侧为 `retry`），wrapper 无法感知 signature 的 RetryCount，影响极小

## Test plan

- [x] 新增 10 条测试：success/failure/retry 状态映射、ctx RoutingKey 提取、DefaultQueue 回退、变参还原、参数/返回值透传、bucket/label 元数据契约
- [x] `go test ./extensions/asynctaskext/ ./extensions/busext/ -count=1` 全部通过（含存量 TestPushConsume——asynctask 走 redis、bus 走 RabbitMQ 的真实收发路径）
- [x] `go vet` / `go build ./extensions/...` 干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)