### PR TITLE
perf: 依线上实测重配 taskDurationBuckets（与 coast 102.0.10rc2 对齐）

### DIFF
--- a/observability/metrics.go
+++ b/observability/metrics.go
@@ -6,9 +6,14 @@ import (
 )
 
 // taskDurationBuckets 与 Python coast 库 coast/celery.py 里的
-// _TASK_DURATION_BUCKETS 完全一致，覆盖秒级 bus 消息到分钟级 asynctask 长任务，
-// 保证跨语言 histogram_quantile 聚合不失真。
-var taskDurationBuckets = []float64{0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600}
+// _TASK_DURATION_BUCKETS 完全一致，保证跨语言 histogram_quantile 聚合不失真
+// （任何一侧单独调整都会让合并查询静默算错，必须同步改）。
+//
+// 档位依线上实测分布选定（单位：秒）：mall prod 与 learning staging 的样本中
+// 99.8% 落在 50ms 以内，故首档下移到 5ms 以分辨「空转 / 真处理」并提供劣化
+// 早期信号；中段覆盖占用 worker 的慢任务；60s 之上进 +Inf 作为告警线
+// （celery 软超时 300s 会杀任务，更长的桶无实际样本）。
+var taskDurationBuckets = []float64{0.005, 0.05, 0.1, 0.5, 1, 10, 60}
 
 // AsyncTaskDurationSeconds 与 Python coast 库的 ASYNC_TASK_DURATION_SECONDS
 // 同名同 label 同 buckets，可以在同一个 Prometheus/Grafana 查询里合并两边的数据。


### PR DESCRIPTION
## 背景

coast 102.0.10rc1 已在 mall（prod）与 learning（staging）灰度，拿到了第一批真实分布数据。结论：**当前这组 bucket 的分辨率全在没有数据的地方**。

| 数据集 | ≤ 首档 50ms 的占比 |
|---|---|
| mall bus（prod，8979 条） | **99.83%** |
| learning asynctask（staging，2417 条） | **98.59%** |

`0.25s ~ 600s` 共 11 档至今**一条样本都没有**。

两个实际后果：

1. **分位数是插值产物，无信息量**——实测 `histogram_quantile` 返回 P50=25.04ms、P95=47.57ms、P99=49.58ms，正好等于 `0.05 × 分位数`；而真实均值只有 4.53ms
2. **劣化不可见**——典型值从 4.5ms 涨到 40ms（9 倍）时桶分布毫无变化，要突破 50ms 才被察觉

## 改动

```go
var taskDurationBuckets = []float64{0.005, 0.05, 0.1, 0.5, 1, 10, 60}
```

- **5ms**：落在空转峰（实测 4.4ms）中间，灵敏度最高，用于分辨「空转 / 真处理」并提供劣化早期信号
- **50ms / 100ms**：真实业务处理区间（mall 自家订单实测落在 50~100ms）
- **0.5s / 1s / 10s**：开始占用 worker 的慢任务
- **60s**：告警线；之上进 `+Inf`（celery 软超时 300s 会杀任务，更长的桶无实际样本）

桶数 13→7，每个 label 组合的 series 16→10（-37.5%）。

## 同步要求

**必须与 coast 逐档一致**，否则跨语言 `sum by (le)` 合并后 `histogram_quantile` 会静默算出错误结果。对应的 coast 改动已发布为 **102.0.10rc2**（`_TASK_DURATION_BUCKETS = (0.005, 0.05, 0.1, 0.5, 1, 10, 60)`），两侧同版本上线。

## Test plan
- [x] `go test ./extensions/busext/ ./extensions/asynctaskext/ -count=1` 全过
- [x] `go build ./...` / `go vet` / `gofmt` 干净

> 本 PR base 指向 #736 的分支，建议并入 #736 后一起进 master（#738 trace PR 亦 stacked 于同一分支）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)