### PR TITLE
feat(entext,redisext,cachext): APM 与 OTel 并存插桩，补齐 DB 与 Redis 链路

### DIFF
--- a/extensions/cachext/backend/redis/redis.go
+++ b/extensions/cachext/backend/redis/redis.go
@@ -14,6 +14,7 @@ import (
 	"github.com/shanbay/gobay"
 	"github.com/shanbay/gobay/extensions/cachext"
 	"github.com/shanbay/gobay/observability"
+	"github.com/shanbay/gobay/observability/redisotelv6"
 )
 
 // go-redis 默认的 PoolSize 是 10*runtime.NumCPU()。NumCPU 读的是宿主机核数，
@@ -61,10 +62,18 @@ type redisBackend struct {
 }
 
 func (b *redisBackend) withContext(ctx context.Context) *redis.Client {
+	// apmgoredis 与 redisotelv6 都只作用于 WithContext 返回的每请求副本，
+	// 因此可以叠加：APM 与 OTel 各自产出 span，而不是二选一。
+	var client *redis.Client
 	if observability.GetApmEnable() {
-		return apmgoredis.Wrap(b.client).WithContext(ctx).RedisClient()
+		client = apmgoredis.Wrap(b.client).WithContext(ctx).RedisClient()
+	} else {
+		client = b.client.WithContext(ctx)
 	}
-	return b.client.WithContext(ctx)
+	if observability.GetOtelEnable() {
+		client = redisotelv6.WrapClient(ctx, client)
+	}
+	return client
 }
 
 func (b *redisBackend) Init(config *viper.Viper) error {

--- a/extensions/entext/ext.go
+++ b/extensions/entext/ext.go
@@ -56,18 +56,16 @@ func (d *EntExt) Init(app *gobay.Application) error {
 
 	var db *sql.DB
 	var err error
-	if observability.GetApmEnable() {
+	apmEnable := observability.GetApmEnable()
+	otelEnable := observability.GetOtelEnable()
+	switch {
+	case apmEnable && otelEnable:
+		db, err = openDualTracedDB(dbDriver, dbURL)
+	case apmEnable:
 		db, err = apmsql.Open(dbDriver, dbURL)
-	} else if observability.GetOtelEnable() {
-		db, err = otelsql.Open(dbDriver, dbURL,
-			otelsql.WithSpanOptions(otelsql.SpanOptions{
-				DisableErrSkip: true,
-				SpanFilter: func(ctx context.Context, method otelsql.Method, query string, args []driver.NamedValue) bool {
-					sc := trace.SpanContextFromContext(ctx)
-					return sc.IsSampled() && sc.IsValid()
-				}}),
-		)
-	} else {
+	case otelEnable:
+		db, err = otelsql.Open(dbDriver, dbURL, otelSpanOption())
+	default:
 		db, err = sql.Open(dbDriver, dbURL)
 	}
 	if err != nil {
@@ -83,6 +81,55 @@ func (d *EntExt) Init(app *gobay.Application) error {
 	d.client = d.NewClient(d.Driver(drv))
 	return nil
 }
+
+// otelSpanOption 是 entext 使用的统一 otelsql 配置。
+func otelSpanOption() otelsql.Option {
+	return otelsql.WithSpanOptions(otelsql.SpanOptions{
+		DisableErrSkip: true,
+		SpanFilter: func(ctx context.Context, method otelsql.Method, query string, args []driver.NamedValue) bool {
+			sc := trace.SpanContextFromContext(ctx)
+			return sc.IsSampled() && sc.IsValid()
+		},
+	})
+}
+
+// openDualTracedDB 在 APM 与 OTel 同时开启时，把两套插桩叠加在同一个 driver 上，
+// 而不是二选一（历史实现里 APM 分支会直接短路掉 OTel，导致 OTel 永远看不到 SQL）。
+//
+// 包装顺序必须是 apmsql 在外、otelsql 在内。database/sql 只对最外层的 driver.Conn
+// 做 driver.Validator 断言，而 otelsql 未实现该接口。若把 otelsql 放在外层，会有两个
+// 后果：连接复用前的健康检查被整体跳过；以及 keepConnOnRollback 变为 false，
+// 事务回滚后连接被销毁而非归还连接池。apmsql 的 conn 静态保证实现 Validator，
+// 放在最外层即可保住这两个行为。
+func openDualTracedDB(dbDriver, dbURL string) (*sql.DB, error) {
+	base, err := sql.Open(dbDriver, dbURL)
+	if err != nil {
+		return nil, err
+	}
+	// 只借用底层 driver。sql.Open 是惰性的，此处尚未建立任何真实连接，
+	// 关掉它是为了不残留 connectionOpener goroutine。
+	raw := base.Driver()
+	if err := base.Close(); err != nil {
+		return nil, err
+	}
+	traced := otelsql.WrapDriver(raw, otelSpanOption())
+	traced = apmsql.Wrap(traced,
+		apmsql.WithDriverName(dbDriver),
+		apmsql.WithDSNParser(apmsql.DriverDSNParser(dbDriver)),
+	)
+	return sql.OpenDB(dsnConnector{dsn: dbURL, drv: traced}), nil
+}
+
+// dsnConnector 把 dsn 与已包装的 driver 组合成 driver.Connector。
+// database/sql 没有「用给定 driver 实例 + dsn 打开」的公开入口，只能走 sql.OpenDB。
+type dsnConnector struct {
+	dsn string
+	drv driver.Driver
+}
+
+func (c dsnConnector) Connect(_ context.Context) (driver.Conn, error) { return c.drv.Open(c.dsn) }
+
+func (c dsnConnector) Driver() driver.Driver { return c.drv }
 
 func (d *EntExt) Close() error { return d.client.Close() }
 

--- a/extensions/entext/tracing_mysql_test.go
+++ b/extensions/entext/tracing_mysql_test.go
@@ -1,0 +1,161 @@
+package entext
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"os"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/XSAM/otelsql"
+	_ "github.com/go-sql-driver/mysql"
+	"go.elastic.co/apm/apmtest"
+	"go.elastic.co/apm/module/apmsql"
+	_ "go.elastic.co/apm/module/apmsql/mysql"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// 这些测试需要真实 MySQL，通过 ENTEXT_TEST_DSN 提供，未设置时跳过
+// （与 apmsql/mysql 自身测试用 MYSQL_HOST 的约定一致）。
+func testDSN(t *testing.T) string {
+	t.Helper()
+	dsn := os.Getenv("ENTEXT_TEST_DSN")
+	if dsn == "" {
+		t.Skip("ENTEXT_TEST_DSN 未设置，跳过")
+	}
+	return dsn
+}
+
+// TestDualTracedDBEmitsBothSpans 验证 APM 与 OTel 双开时，同一条 SQL 在两套链路
+// 里各产出一个 span——这是本次改动的核心目的。
+func TestDualTracedDBEmitsBothSpans(t *testing.T) {
+	dsn := testDSN(t)
+
+	// otelsql 在包装时从全局 TracerProvider 取 tracer，必须先设置。
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSyncer(exp),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	db, err := openDualTracedDB("mysql", dsn)
+	if err != nil {
+		t.Fatalf("openDualTracedDB 失败: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, apmSpans, _ := apmtest.WithTransaction(func(ctx context.Context) {
+		ctx, span := tp.Tracer("entext-test").Start(ctx, "parent")
+		defer span.End()
+
+		var n int
+		if err := db.QueryRowContext(ctx, "SELECT 1").Scan(&n); err != nil {
+			t.Errorf("查询失败: %v", err)
+			return
+		}
+		if n != 1 {
+			t.Errorf("SELECT 1 返回 %d", n)
+		}
+	})
+
+	var apmDBSpan bool
+	for _, s := range apmSpans {
+		t.Logf("APM span: name=%q type=%q subtype=%q", s.Name, s.Type, s.Subtype)
+		if s.Subtype == "mysql" {
+			apmDBSpan = true
+		}
+	}
+	if !apmDBSpan {
+		t.Errorf("APM 侧没有产出 mysql span，共 %d 个 span", len(apmSpans))
+	}
+
+	var otelDBSpan bool
+	for _, s := range exp.GetSpans() {
+		t.Logf("OTel span: name=%q kind=%v", s.Name, s.SpanKind)
+		if s.Name != "parent" && strings.Contains(strings.ToLower(s.Name), "sql") {
+			otelDBSpan = true
+		}
+	}
+	if !otelDBSpan {
+		t.Errorf("OTel 侧没有产出 SQL span，共 %d 个 span", len(exp.GetSpans()))
+	}
+}
+
+// countingDriver 统计真实的物理连接建立次数，放在包装链最内层。
+type countingDriver struct {
+	driver.Driver
+	opens atomic.Int64
+}
+
+func (d *countingDriver) Open(name string) (driver.Conn, error) {
+	d.opens.Add(1)
+	return d.Driver.Open(name)
+}
+
+// TestDualTracedDBCtxCancelKeepsConn 锁定包装顺序对连接池的实际影响。
+//
+// database/sql 的 keepConnOnRollback 取决于最外层 driver.Conn 是否实现
+// driver.Validator（sql.go:1904），它只在 (*Tx).awaitDone 里生效（sql.go:2220），
+// 即只影响事务 ctx 被取消/超时的路径。若把未实现 Validator 的 otelsql 放到外层，
+// 每个被取消的事务都会销毁自己的连接。
+//
+// 实测：30 次「事务+查询+ctx取消」，apmsql 在外新建 1 条连接，otelsql 在外新建 30 条。
+func TestDualTracedDBCtxCancelKeepsConn(t *testing.T) {
+	dsn := testDSN(t)
+	const rounds = 30
+
+	base, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	counter := &countingDriver{Driver: base.Driver()}
+	_ = base.Close()
+
+	// 与 openDualTracedDB 相同的包装顺序，只是最内层多一个计数器。
+	traced := otelsql.WrapDriver(counter, otelSpanOption())
+	traced = apmsql.Wrap(traced,
+		apmsql.WithDriverName("mysql"),
+		apmsql.WithDSNParser(apmsql.DriverDSNParser("mysql")),
+	)
+	db := sql.OpenDB(dsnConnector{dsn: dsn, drv: traced})
+	db.SetMaxOpenConns(2)
+	db.SetMaxIdleConns(2)
+	t.Cleanup(func() { _ = db.Close() })
+
+	if err := db.PingContext(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	before := counter.opens.Load()
+
+	for i := 0; i < rounds; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			cancel()
+			t.Fatal(err)
+		}
+		var n int
+		if err := tx.QueryRowContext(ctx, "SELECT 1").Scan(&n); err != nil {
+			cancel()
+			t.Fatal(err)
+		}
+		cancel() // 触发 awaitDone -> rollback(discardConn)
+		for j := 0; j < 5000 && db.Stats().InUse > 0; j++ {
+			runtime.Gosched()
+		}
+	}
+
+	opened := counter.opens.Load() - before
+	t.Logf("%d 次「事务+查询+ctx取消」后新建连接数 = %d", rounds, opened)
+	if opened > rounds/3 {
+		t.Errorf("新建连接数 %d 过高（%d 轮）：连接在 ctx 取消后被销毁而非归还连接池，"+
+			"说明最外层 conn 未实现 driver.Validator——包装顺序被改动了", opened, rounds)
+	}
+}

--- a/extensions/entext/tracing_test.go
+++ b/extensions/entext/tracing_test.go
@@ -1,0 +1,64 @@
+package entext
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"testing"
+)
+
+// fakeConn 实现 driver.Validator，模拟 go-sql-driver/mysql 的行为。
+type fakeConn struct{}
+
+func (fakeConn) Prepare(string) (driver.Stmt, error) { return nil, driver.ErrSkip }
+func (fakeConn) Close() error                        { return nil }
+func (fakeConn) Begin() (driver.Tx, error)           { return nil, driver.ErrSkip }
+func (fakeConn) IsValid() bool                       { return true }
+
+var _ driver.Validator = fakeConn{}
+
+type fakeDriver struct{}
+
+func (fakeDriver) Open(string) (driver.Conn, error) { return fakeConn{}, nil }
+
+func init() { sql.Register("entext-fake", fakeDriver{}) }
+
+// TestDualTracedDBKeepsValidator 锁定 APM/OTel 双开时的包装顺序。
+//
+// database/sql 只对最外层 driver.Conn 做 driver.Validator 断言：一处用于连接复用前的
+// 健康检查，一处用于决定 keepConnOnRollback（事务回滚后连接是否归还连接池）。otelsql
+// 未实现该接口，因此它必须在内层、apmsql 在外层。若有人调换顺序，本测试会失败。
+func TestDualTracedDBKeepsValidator(t *testing.T) {
+	db, err := openDualTracedDB("entext-fake", "fake-dsn")
+	if err != nil {
+		t.Fatalf("openDualTracedDB 失败: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	conn, err := db.Driver().Open("fake-dsn")
+	if err != nil {
+		t.Fatalf("打开连接失败: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	if _, ok := conn.(driver.Validator); !ok {
+		t.Fatalf("最外层 conn 未实现 driver.Validator："+
+			"包装顺序被改动了。apmsql 必须在外层、otelsql 在内层，"+
+			"否则连接健康检查失效且事务回滚后连接不再复用。实际类型 %T", conn)
+	}
+}
+
+// TestDualTracedDBConnectorUsesDSN 确认 dsnConnector 把 dsn 透传给了底层 driver。
+func TestDualTracedDBConnectorUsesDSN(t *testing.T) {
+	c := dsnConnector{dsn: "fake-dsn", drv: fakeDriver{}}
+	conn, err := c.Connect(context.Background())
+	if err != nil {
+		t.Fatalf("Connect 失败: %v", err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatalf("Close 失败: %v", err)
+	}
+	if c.Driver() == nil {
+		t.Fatal("Driver() 返回 nil")
+	}
+}

--- a/extensions/redisext/ext.go
+++ b/extensions/redisext/ext.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-redis/redis"
 	"github.com/shanbay/gobay"
 	"github.com/shanbay/gobay/observability"
+	"github.com/shanbay/gobay/observability/redisotelv6"
 	"go.elastic.co/apm/module/apmgoredis"
 )
 
@@ -22,6 +23,7 @@ type RedisExt struct {
 	redisclient    *redis.Client
 	apmable        bool
 	apmredisclient apmgoredis.Client
+	otelable       bool
 }
 
 var _ gobay.Extension = (*RedisExt)(nil)
@@ -65,6 +67,7 @@ func (c *RedisExt) Init(app *gobay.Application) error {
 		c.apmable = true
 		c.apmredisclient = apmgoredis.Wrap(c.redisclient)
 	}
+	c.otelable = observability.GetOtelEnable()
 	_, err := c.redisclient.Ping().Result()
 	return err
 }
@@ -119,10 +122,18 @@ func (c *RedisExt) Application() *gobay.Application {
 }
 
 func (c *RedisExt) Client(ctx context.Context) *redis.Client {
+	// apmgoredis 与 redisotelv6 都只作用于 WithContext 返回的每请求副本，
+	// 因此可以叠加：APM 与 OTel 各自产出 span，而不是二选一。
+	var client *redis.Client
 	if c.apmable {
-		return c.apmredisclient.WithContext(ctx).RedisClient()
+		client = c.apmredisclient.WithContext(ctx).RedisClient()
+	} else {
+		client = c.redisclient.WithContext(ctx)
 	}
-	return c.redisclient.WithContext(ctx)
+	if c.otelable {
+		client = redisotelv6.WrapClient(ctx, client)
+	}
+	return client
 }
 
 func (c *RedisExt) EvalLua(ctx context.Context, script string, keys []string, args ...any) (any, error) {

--- a/extensions/redisext/tracing_test.go
+++ b/extensions/redisext/tracing_test.go
@@ -1,0 +1,86 @@
+package redisext_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.elastic.co/apm/apmtest"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/shanbay/gobay"
+	"github.com/shanbay/gobay/extensions/redisext"
+)
+
+// TestClientEmitsBothSpans 端到端验证：APM 与 OTel 双开时，一条经由
+// RedisExt.Client(ctx) 执行的命令会在两套链路里各产出一个 span。
+//
+// 需要 testdata/config.yaml 里配置的 Redis 可达（与本包其他测试一致）。
+func TestClientEmitsBothSpans(t *testing.T) {
+	// 必须在 Init 之前设置：两个开关都是在 Init 里读环境变量的。
+	t.Setenv("APM_ENABLE", "true")
+	t.Setenv("OTEL_ENABLE", "true")
+
+	ext := &redisext.RedisExt{NS: "redis_"}
+	app, err := gobay.CreateApp("../../testdata/", "testing",
+		map[gobay.Key]gobay.Extension{"redis": ext})
+	if err != nil {
+		t.Fatalf("CreateApp 失败（Redis 不可达？）: %v", err)
+	}
+	t.Cleanup(func() { _ = app.Close() })
+
+	// 必须在 CreateApp 之后设置：OTEL_ENABLE=true 时 gobay 自身会在 app 初始化里
+	// 调用 otel.SetTracerProvider，先设会被它覆盖掉。
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSyncer(exp),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prev)
+		_ = tp.Shutdown(context.Background())
+	})
+
+	const key = "gobay-redisext-tracing-test"
+
+	_, apmSpans, _ := apmtest.WithTransaction(func(ctx context.Context) {
+		ctx, parent := tp.Tracer("test").Start(ctx, "parent")
+		defer parent.End()
+
+		if err := ext.Client(ctx).Set(key, "hello", 10*time.Second).Err(); err != nil {
+			t.Errorf("SET 失败: %v", err)
+			return
+		}
+		if _, err := ext.Client(ctx).Get(key).Result(); err != nil {
+			t.Errorf("GET 失败: %v", err)
+		}
+		ext.Client(ctx).Del(key)
+	})
+
+	var apmRedis int
+	for _, s := range apmSpans {
+		if s.Subtype == "redis" {
+			apmRedis++
+		}
+	}
+	if apmRedis == 0 {
+		t.Errorf("APM 侧没有 redis span，共 %d 个 span", len(apmSpans))
+	}
+
+	otelRedis := map[string]int{}
+	for _, s := range exp.GetSpans() {
+		if s.Name != "parent" {
+			otelRedis[s.Name]++
+		}
+	}
+	t.Logf("APM redis span 数=%d；OTel span=%v", apmRedis, otelRedis)
+	for _, want := range []string{"set", "get", "del"} {
+		if otelRedis[want] == 0 {
+			t.Errorf("OTel 侧缺少 %q span，实际 %v", want, otelRedis)
+		}
+	}
+}

--- a/observability/redisotelv6/tracing.go
+++ b/observability/redisotelv6/tracing.go
@@ -1,0 +1,183 @@
+// Package redisotelv6 为 go-redis v6 客户端提供 OpenTelemetry 链路追踪。
+//
+// go-redis v9 有官方的 redisotel，v6 没有：v6 的命令方法不接收 context，
+// 唯一能拿到 ctx 的地方是 (*redis.Client).WithContext 返回的每请求副本。本包在该
+// 副本上用 WrapProcess / WrapProcessPipeline 挂钩子，钩子闭包捕获 ctx —— 这与
+// go.elastic.co/apm/module/apmgoredis 的做法完全一致，因此两者可以叠加在同一个
+// 副本上，APM 与 OTel 各自产出 span，不必二选一。
+//
+// 之所以只能作用于每请求副本：WrapProcess 是 (c.process = fn(c.process)) 的原地
+// 修改。go-redis v6 的 Client 值嵌入 baseClient，clone() 走值拷贝，因此在副本上
+// 挂钩子不会影响基础 client、也不会跨请求累积。
+//
+// span 名与属性对齐 redisotel/v9，便于 v6 / v9 两条路径的数据在同一套看板里查询。
+package redisotelv6
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/go-redis/redis"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// TracerName 是本包创建 span 时使用的 instrumentation name。
+const TracerName = "github.com/shanbay/gobay/observability/redisotelv6"
+
+// 与 redisotel/v9 依赖的 rediscmd.AppendCmd 保持一致的截断口径。
+const (
+	numArgLimit = 32
+	argLenLimit = 64
+)
+
+// WrapClient 在 client 上挂 OTel 追踪钩子并返回它。
+//
+// 传入的必须是 (*redis.Client).WithContext(ctx) 返回的**每请求副本**（gobay 的
+// redisext.Client / cachext 的 withContext 都是这样拿的），否则钩子会挂到共享的
+// 基础 client 上并跨请求累积。
+//
+// 仅当 ctx 中已有「有效且被采样」的 span 上下文时才产出 span，与 entext 里
+// otelsql 的 SpanFilter 口径一致：既避免在无 trace 上下文时产生大量孤儿 root
+// span，也保证被采样的链路是完整的。这是与 redisotel/v9 的一处有意差异。
+func WrapClient(ctx context.Context, client *redis.Client) *redis.Client {
+	if client == nil {
+		return nil
+	}
+	if !shouldTrace(ctx) {
+		return client
+	}
+	tracer := otel.GetTracerProvider().Tracer(TracerName)
+
+	client.WrapProcess(func(oldProcess func(redis.Cmder) error) func(redis.Cmder) error {
+		return func(cmd redis.Cmder) error {
+			_, span := tracer.Start(ctx, cmd.Name(),
+				trace.WithSpanKind(trace.SpanKindClient),
+				trace.WithAttributes(
+					semconv.DBSystemRedis,
+					semconv.DBStatement(cmdString(cmd)),
+				),
+			)
+			defer span.End()
+
+			err := oldProcess(cmd)
+			recordError(span, err)
+			return err
+		}
+	})
+
+	client.WrapProcessPipeline(func(oldProcess func([]redis.Cmder) error) func([]redis.Cmder) error {
+		return func(cmds []redis.Cmder) error {
+			_, span := tracer.Start(ctx, "redis.pipeline "+pipelineSummary(cmds),
+				trace.WithSpanKind(trace.SpanKindClient),
+				trace.WithAttributes(
+					semconv.DBSystemRedis,
+					semconv.DBStatement(cmdsString(cmds)),
+					attribute.Int("db.redis.num_cmd", len(cmds)),
+				),
+			)
+			defer span.End()
+
+			err := oldProcess(cmds)
+			recordError(span, err)
+			return err
+		}
+	})
+
+	return client
+}
+
+// shouldTrace 与 entext 中 otelsql 的 SpanFilter 判据保持一致。
+func shouldTrace(ctx context.Context) bool {
+	sc := trace.SpanContextFromContext(ctx)
+	return sc.IsValid() && sc.IsSampled()
+}
+
+// recordError 不把 redis.Nil（键不存在）当成错误，与 redisotel/v9 一致。
+func recordError(span trace.Span, err error) {
+	if err == nil || err == redis.Nil {
+		return
+	}
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
+}
+
+func pipelineSummary(cmds []redis.Cmder) string {
+	switch len(cmds) {
+	case 0:
+		return "(empty)"
+	case 1:
+		return cmds[0].Name()
+	default:
+		return cmds[0].Name() + " ... " + cmds[len(cmds)-1].Name()
+	}
+}
+
+func cmdsString(cmds []redis.Cmder) string {
+	b := make([]byte, 0, 64)
+	for i, cmd := range cmds {
+		if i > numArgLimit {
+			break
+		}
+		if i > 0 {
+			b = append(b, '\n')
+		}
+		b = appendCmd(b, cmd)
+	}
+	return string(b)
+}
+
+func cmdString(cmd redis.Cmder) string {
+	return string(appendCmd(make([]byte, 0, 64), cmd))
+}
+
+func appendCmd(b []byte, cmd redis.Cmder) []byte {
+	for i, arg := range cmd.Args() {
+		if i > numArgLimit {
+			break
+		}
+		if i > 0 {
+			b = append(b, ' ')
+		}
+		b = appendArg(b, arg)
+	}
+	if err := cmd.Err(); err != nil && err != redis.Nil {
+		b = append(b, ": "...)
+		b = append(b, err.Error()...)
+	}
+	return b
+}
+
+func appendArg(b []byte, v interface{}) []byte {
+	switch v := v.(type) {
+	case nil:
+		return append(b, "<nil>"...)
+	case string:
+		return appendTruncated(b, v)
+	case []byte:
+		return appendTruncated(b, string(v))
+	case int:
+		return strconv.AppendInt(b, int64(v), 10)
+	case int64:
+		return strconv.AppendInt(b, v, 10)
+	case uint64:
+		return strconv.AppendUint(b, v, 10)
+	case float64:
+		return strconv.AppendFloat(b, v, 'f', -1, 64)
+	case bool:
+		return strconv.AppendBool(b, v)
+	default:
+		return appendTruncated(b, fmt.Sprint(v))
+	}
+}
+
+func appendTruncated(b []byte, s string) []byte {
+	if len(s) > argLenLimit {
+		s = s[:argLenLimit]
+	}
+	return append(b, s...)
+}

--- a/observability/redisotelv6/tracing_test.go
+++ b/observability/redisotelv6/tracing_test.go
@@ -1,0 +1,211 @@
+package redisotelv6
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-redis/redis"
+	"go.elastic.co/apm/apmtest"
+	"go.elastic.co/apm/module/apmgoredis"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// 指向一个必定连不上的端口：命令一定失败，但 Cmder 与 span 照常产生，
+// 因此这些测试不需要真实 Redis。
+func deadClient() *redis.Client {
+	return redis.NewClient(&redis.Options{
+		Addr:        "127.0.0.1:1",
+		MaxRetries:  0,
+		DialTimeout: 50 * time.Millisecond,
+	})
+}
+
+func recorder(t *testing.T) (*tracetest.InMemoryExporter, *sdktrace.TracerProvider) {
+	t.Helper()
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSyncer(exp),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	// WrapClient 从全局 TracerProvider 取 tracer，测试里必须把它设上，
+	// 否则 span 会进 no-op provider。
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prev)
+		_ = tp.Shutdown(context.Background())
+	})
+	return exp, tp
+}
+
+// sampledCtx 返回一个带「有效且被采样」span 的 ctx，并把该 span 结束掉，
+// 避免它混进断言。
+func sampledCtx(t *testing.T, tp *sdktrace.TracerProvider) context.Context {
+	t.Helper()
+	ctx, span := tp.Tracer("test").Start(context.Background(), "parent")
+	span.End()
+	return ctx
+}
+
+func TestWrapClientEmitsSpan(t *testing.T) {
+	exp, tp := recorder(t)
+	ctx := sampledCtx(t, tp)
+
+	base := deadClient()
+	t.Cleanup(func() { _ = base.Close() })
+
+	client := WrapClient(ctx, base.WithContext(ctx))
+	_ = client.Get("some-key").Err() // 必然失败，但 span 应当产生
+
+	var got trace.SpanKind
+	var found bool
+	var stmt string
+	for _, s := range exp.GetSpans() {
+		if s.Name == "parent" {
+			continue
+		}
+		found = true
+		got = s.SpanKind
+		if s.Name != "get" {
+			t.Errorf("span 名应为命令名 get，实际 %q", s.Name)
+		}
+		for _, a := range s.Attributes {
+			switch string(a.Key) {
+			case "db.system":
+				if a.Value.AsString() != "redis" {
+					t.Errorf("db.system 应为 redis，实际 %q", a.Value.AsString())
+				}
+			case "db.statement":
+				stmt = a.Value.AsString()
+			}
+		}
+		if s.Status.Code == 0 {
+			t.Error("连接失败时 span 状态应为 Error")
+		}
+	}
+	if !found {
+		t.Fatal("没有产出 redis span")
+	}
+	if got != trace.SpanKindClient {
+		t.Errorf("SpanKind 应为 client，实际 %v", got)
+	}
+	if !strings.HasPrefix(stmt, "get some-key") {
+		t.Errorf("db.statement 应以命令和参数开头，实际 %q", stmt)
+	}
+}
+
+// TestWrapClientSkipsWithoutSampledContext —— 无 trace 上下文时不产出 span，
+// 避免大量孤儿 root span。这是与 redisotel/v9 的有意差异。
+func TestWrapClientSkipsWithoutSampledContext(t *testing.T) {
+	exp, _ := recorder(t)
+
+	base := deadClient()
+	t.Cleanup(func() { _ = base.Close() })
+
+	ctx := context.Background()
+	client := WrapClient(ctx, base.WithContext(ctx))
+	_ = client.Get("some-key").Err()
+
+	if n := len(exp.GetSpans()); n != 0 {
+		t.Errorf("无采样上下文时不应产出 span，实际 %d 个", n)
+	}
+}
+
+// TestWrapClientDoesNotLeakToBaseClient 是本包最关键的安全前提：
+// 钩子必须只作用于 WithContext 返回的每请求副本。若它污染了基础 client，
+// 钩子会跨请求累积（既是内存泄漏，也会让 span 绑到过期的 ctx 上）。
+func TestWrapClientDoesNotLeakToBaseClient(t *testing.T) {
+	exp, tp := recorder(t)
+	ctx := sampledCtx(t, tp)
+
+	base := deadClient()
+	t.Cleanup(func() { _ = base.Close() })
+
+	// 连续包装 5 个每请求副本
+	for i := 0; i < 5; i++ {
+		_ = WrapClient(ctx, base.WithContext(ctx))
+	}
+	exp.Reset()
+
+	// 直接用基础 client 执行命令：不应产生任何 span
+	_ = base.Get("some-key").Err()
+	if n := len(exp.GetSpans()); n != 0 {
+		t.Fatalf("基础 client 被污染了：产出了 %d 个 span，说明钩子会跨请求累积", n)
+	}
+
+	// 而每请求副本仍应正常产出，且恰好一个（没有重复挂钩）
+	exp.Reset()
+	client := WrapClient(ctx, base.WithContext(ctx))
+	_ = client.Get("some-key").Err()
+	if n := len(exp.GetSpans()); n != 1 {
+		t.Fatalf("每请求副本应恰好产出 1 个 span，实际 %d 个", n)
+	}
+}
+
+func TestAppendArgTruncates(t *testing.T) {
+	long := strings.Repeat("x", 200)
+	got := string(appendArg(nil, long))
+	if len(got) != argLenLimit {
+		t.Errorf("长参数应截断到 %d 字节，实际 %d", argLenLimit, len(got))
+	}
+	if n := string(appendArg(nil, nil)); n != "<nil>" {
+		t.Errorf("nil 参数应渲染为 <nil>，实际 %q", n)
+	}
+	if n := string(appendArg(nil, 42)); n != "42" {
+		t.Errorf("int 参数应渲染为 42，实际 %q", n)
+	}
+}
+
+// TestCoexistsWithAPM 验证本包与 apmgoredis 叠加在同一个每请求副本上时，
+// 一条命令会在两套链路里各产出一个 span，而不是二选一。
+//
+// 这里的组合顺序与 redisext.Client / cachext 的 withContext 完全一致：
+// 先 apmgoredis.Wrap(...).WithContext(ctx).RedisClient()，再 WrapClient(ctx, ...)。
+// 命令打向死端口必然失败，但两个钩子都会照常建 span，因此无需真实 Redis。
+func TestCoexistsWithAPM(t *testing.T) {
+	exp, tp := recorder(t)
+
+	base := deadClient()
+	t.Cleanup(func() { _ = base.Close() })
+
+	_, apmSpans, _ := apmtest.WithTransaction(func(ctx context.Context) {
+		ctx, parent := tp.Tracer("test").Start(ctx, "parent")
+		defer parent.End()
+
+		client := apmgoredis.Wrap(base).WithContext(ctx).RedisClient()
+		client = WrapClient(ctx, client)
+		_ = client.Get("some-key").Err()
+	})
+
+	// —— APM 侧 ——
+	var apmRedisSpan bool
+	for _, s := range apmSpans {
+		t.Logf("APM span: name=%q type=%q subtype=%q", s.Name, s.Type, s.Subtype)
+		if s.Subtype == "redis" {
+			apmRedisSpan = true
+		}
+	}
+	if !apmRedisSpan {
+		t.Errorf("APM 侧没有产出 redis span，共 %d 个", len(apmSpans))
+	}
+
+	// —— OTel 侧 ——
+	var otelRedisSpan bool
+	for _, s := range exp.GetSpans() {
+		if s.Name == "parent" {
+			continue
+		}
+		t.Logf("OTel span: name=%q kind=%v", s.Name, s.SpanKind)
+		if s.Name == "get" {
+			otelRedisSpan = true
+		}
+	}
+	if !otelRedisSpan {
+		t.Errorf("OTel 侧没有产出 redis span，共 %d 个", len(exp.GetSpans()))
+	}
+}


### PR DESCRIPTION
> 本 PR 合并了原 #743（DB）与 #744（Redis）。两处都是「APM 开着时 OTel 看不到」的同一类问题，放在一起便于统一测试与 review，#744 已关闭。

## 问题

生产上 **828 个 Deployment 同时设置了 `APM_ENABLE=true` 和 `OTEL_ENABLE=true`**（仅 OTel 4 个、仅 APM 5 个）。在这个配置下，OTel 侧**看不到任何 DB 与 Redis 操作** —— 应用的 Server span 表现为持续数秒、**没有任何子 span 的叶子节点**，排查慢请求时无法判断时间耗在哪。

两处成因不同：

**DB** —— `extensions/entext/ext.go` 是 `if / else if`：

```go
if observability.GetApmEnable() {
    db, err = apmsql.Open(dbDriver, dbURL)      // 命中即结束
} else if observability.GetOtelEnable() {
    db, err = otelsql.Open(dbDriver, dbURL, …)  // 永远走不到
}
```

**Redis** —— `extensions/redisext` 与 `extensions/cachext/backend/redis`（go-redis **v6**）只 import 了 `apmgoredis`，**零 otel 引用**。OTel 插桩只存在于 v9 变体里。

## 改动一：DB —— 双开时叠加，不再二选一

```go
switch {
case apmEnable && otelEnable:
    db, err = openDualTracedDB(dbDriver, dbURL)
case apmEnable:
    db, err = apmsql.Open(dbDriver, dbURL)
case otelEnable:
    db, err = otelsql.Open(dbDriver, dbURL, otelSpanOption())
default:
    db, err = sql.Open(dbDriver, dbURL)
}
```

单开与全关路径行为不变。

### 包装顺序必须是 apmsql 在外、otelsql 在内

`database/sql` 只对**最外层** `driver.Conn` 做 `driver.Validator` 断言，共两处：`sql.go:618` 的 `validateConnection`，以及 `sql.go:1904` 的 `keepConnOnRollback`。

`otelsql v0.30.0` **未实现** `driver.Validator`（全包 grep `IsValid` 零命中）；`apmsql` 有静态断言 `var _ driver.Validator = (*conn)(nil)`。

`keepConnOnRollback` 只在 `(*Tx).awaitDone` 里生效（`sql.go:2220`），即**只影响事务 ctx 被取消/超时的路径**，显式 `tx.Rollback()` 不受影响。但这恰是需要这份可观测性的场景。实测 30 次「事务 + 查询 + ctx 取消」的物理连接建立次数：

| 包装顺序 | 新建连接数 |
| --- | --- |
| **apmsql 在外（本 PR）** | **0 ~ 1** |
| otelsql 在外 | **30** |

DSN 解析用公开的 `apmsql.DriverDSNParser(dbDriver)` 取回注册时的 parser，未注册时其自身兜底 `genericDSNParser`，APM span 的 db host / instance 属性不受影响。

## 改动二：Redis —— v6 上补 OTel，与 apmgoredis 并存

**不走「迁 go-redis v9」这条路**：Elastic APM 没有 v9 模块（`apmgoredis` 只覆盖 v6/v7），迁过去等于拿 Redis 的 APM 数据换 OTel 数据，而 APM 目前不能关。何况 `redisext` 用的是 v6.15.9（不是 v8），迁 v9 要给每个命令加 ctx 参数。

新增 `observability/redisotelv6`。v6 的命令方法不接收 `context`，唯一能拿到 ctx 的地方是 `(*redis.Client).WithContext` 返回的**每请求副本**；本包在该副本上用 `WrapProcess` / `WrapProcessPipeline` 挂钩子、闭包捕获 ctx —— 与 `apmgoredis` 做法一致，因此两者能叠加（`WrapProcess` 是 `c.process = fn(c.process)` 的组合式修改）。

**安全前提**（已在 go-redis v6.15.9 源码核实）：`Client` **值嵌入** `baseClient`、`process` 是 `baseClient` 的字段、`clone()` 是值拷贝、`init()` 不重置 `process`。所以副本上挂钩子既不污染基础 client、也不跨请求累积。`TestWrapClientDoesNotLeakToBaseClient` 钉死了这一点。

接入点各一处，覆盖完整：

| 文件 | 位置 | 覆盖 |
| --- | --- | --- |
| `extensions/redisext/ext.go` | `Client(ctx)` | 所有 Redis 调用，含 `EvalLua` |
| `extensions/cachext/backend/redis/redis.go` | `withContext(ctx)` | 所有 Cache 操作 |

span 约定对齐 `redisotel/v9`（命令名 / `SpanKind=Client` / `db.system=redis` / `db.statement` 限 32 参数 × 64 字节 / `redis.Nil` 不记为错误）。**一处有意差异**：仅当 ctx 已有「有效且被采样」的 span 上下文时才产出 span，与 `entext` 里 `otelsql` 的 `SpanFilter` 口径一致，避免无 trace 上下文时产生大量孤儿 root span。

`apmgoredis` 那条链**一行未动**。

## 测试

**不依赖外部服务**（fake driver / 死端口）：

- `TestDualTracedDBKeepsValidator` —— 锁定 DB 包装顺序。反向验证过：调换成 otelsql 在外时失败，报 `实际类型 *otelsql.otConn`
- `TestDualTracedDBConnectorUsesDSN`
- `TestWrapClientEmitsSpan` / `TestWrapClientSkipsWithoutSampledContext` / `TestAppendArgTruncates`
- `TestWrapClientDoesNotLeakToBaseClient` —— 上面那条安全前提
- `TestCoexistsWithAPM` —— Redis 侧叠加验证

**需要真实 MySQL / Redis**（env 未设时跳过）：

- `TestDualTracedDBEmitsBothSpans`
- `TestDualTracedDBCtxCancelKeepsConn` —— 上表那组连接数字，用放在包装链最内层的计数 driver 统计
- `TestClientEmitsBothSpans` —— 走完整的 `RedisExt.Client(ctx)`

### 合并后的统一测试实测（MySQL 8.0 + Redis 7）

```
DB   —— APM  span: name="SELECT"         type="db"  subtype="mysql"
        OTel span: sql.conn.query / sql.rows (kind=client)
Redis —— APM  span: name="GET"           type="db"  subtype="redis"
        OTel span: name="get" (kind=client)
        走 RedisExt.Client(ctx): APM 3 个 redis span，OTel set/get/del 各 1 个
连接池 —— 30 次「事务+查询+ctx取消」后新建连接数 = 1
```

四象限矩阵，`observability/...` + `entext` + `redisext` + `cachext` 共 7 个包：

| 组合 | 结果 |
| --- | --- |
| APM=true OTEL=true | 7 ok / 0 fail |
| APM=true OTEL=false | 7 ok / 0 fail |
| APM=false OTEL=true | 7 ok / 0 fail |
| 都不设 | 7 ok / 0 fail |

外加全模块 `go build ./...` / `go vet ./...` / `gofmt` 干净。

## 合入前建议关注

1. **span 量会显著放大**，Redis 尤甚（调用频次远高于 SQL）。gobay 用的是 `sdktrace.NewBatchSpanProcessor(traceExporter)` 全默认参数（MaxQueueSize 2048 / MaxExportBatchSize 512 / BatchTimeout 5s），队列溢出时丢弃只在 `global.Debug` 里计数、业务侧无感。**灰度时务必同步调大 `OTEL_BSP_MAX_QUEUE_SIZE` 并监控 dropped。**
2. **不建议全量放开**。otel-collector 目前单副本、`tail_sampling` decision_wait 10s，需把每条 trace 的全部 span 在内存缓存 10 秒；828 个服务同时开始发 DB/Redis span 有 OOM 风险。扩副本前需先上 `loadbalancing` exporter 做 trace ID 亲和。
3. **`openDualTracedDB` 走 `dsnConnector`**，绕过了 `driver.DriverContext`/`OpenConnector`，每建一条新连接会重新解析 DSN。稳态下无影响，但值得 review 确认可接受。
4. **`db.statement` 会带上参数值**（Redis 侧截断到 64 字节），即缓存 key 和 value 前 64 字节会进 trace。这是对齐 v9 的默认行为；若认为不合适，改 `WrapClient` 里 `semconv.DBStatement(cmdString(cmd))` 一处即可。
5. **残留缺口**：即便 DB 侧顺序正确，`apmsql` 的 `IsValid()` 在内层 conn 不实现 Validator 时恒返回 `true`，底层 mysql driver 自己的 `IsValid` 仍到达不了（`sql.go:618` 那处健康检查形同虚设）。要彻底解决需给 otelsql 补 Validator 转发（可参照仓库已有的 `shanbay/go-redis/extra/redisotel/v9` fork 先例）。

> 说明：本 PR 只影响 Go 服务。Python（coast）侧已由 `peeweext`（DB，`MySQLClientInstrumentor`）与 `cachext`（Redis，`RedisInstrumentor`）覆盖，实测有 SQL 与 Redis span，无需改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4eaUum99JDRLs5wrJETp8
