### PR TITLE
feat(redisext,cachext): go-redis v6 补 OTel 追踪，与 APM 并存

### DIFF
--- a/extensions/cachext/backend/redis/redis.go
+++ b/extensions/cachext/backend/redis/redis.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/shanbay/gobay/extensions/cachext"
 	"github.com/shanbay/gobay/observability"
+	"github.com/shanbay/gobay/observability/redisotelv6"
 )
 
 func init() {
@@ -23,10 +24,18 @@ type redisBackend struct {
 }
 
 func (b *redisBackend) withContext(ctx context.Context) *redis.Client {
+	// apmgoredis 与 redisotelv6 都只作用于 WithContext 返回的每请求副本，
+	// 因此可以叠加：APM 与 OTel 各自产出 span，而不是二选一。
+	var client *redis.Client
 	if observability.GetApmEnable() {
-		return apmgoredis.Wrap(b.client).WithContext(ctx).RedisClient()
+		client = apmgoredis.Wrap(b.client).WithContext(ctx).RedisClient()
+	} else {
+		client = b.client.WithContext(ctx)
 	}
-	return b.client.WithContext(ctx)
+	if observability.GetOtelEnable() {
+		client = redisotelv6.WrapClient(ctx, client)
+	}
+	return client
 }
 
 func (b *redisBackend) Init(config *viper.Viper) error {

--- a/extensions/redisext/ext.go
+++ b/extensions/redisext/ext.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-redis/redis"
 	"github.com/shanbay/gobay"
 	"github.com/shanbay/gobay/observability"
+	"github.com/shanbay/gobay/observability/redisotelv6"
 	"go.elastic.co/apm/module/apmgoredis"
 )
 
@@ -22,6 +23,7 @@ type RedisExt struct {
 	redisclient    *redis.Client
 	apmable        bool
 	apmredisclient apmgoredis.Client
+	otelable       bool
 }
 
 var _ gobay.Extension = (*RedisExt)(nil)
@@ -42,6 +44,7 @@ func (c *RedisExt) Init(app *gobay.Application) error {
 		c.apmable = true
 		c.apmredisclient = apmgoredis.Wrap(c.redisclient)
 	}
+	c.otelable = observability.GetOtelEnable()
 	_, err := c.redisclient.Ping().Result()
 	return err
 }
@@ -96,10 +99,18 @@ func (c *RedisExt) Application() *gobay.Application {
 }
 
 func (c *RedisExt) Client(ctx context.Context) *redis.Client {
+	// apmgoredis 与 redisotelv6 都只作用于 WithContext 返回的每请求副本，
+	// 因此可以叠加：APM 与 OTel 各自产出 span，而不是二选一。
+	var client *redis.Client
 	if c.apmable {
-		return c.apmredisclient.WithContext(ctx).RedisClient()
+		client = c.apmredisclient.WithContext(ctx).RedisClient()
+	} else {
+		client = c.redisclient.WithContext(ctx)
 	}
-	return c.redisclient.WithContext(ctx)
+	if c.otelable {
+		client = redisotelv6.WrapClient(ctx, client)
+	}
+	return client
 }
 
 func (c *RedisExt) EvalLua(ctx context.Context, script string, keys []string, args ...any) (any, error) {

--- a/extensions/redisext/tracing_test.go
+++ b/extensions/redisext/tracing_test.go
@@ -1,0 +1,86 @@
+package redisext_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.elastic.co/apm/apmtest"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/shanbay/gobay"
+	"github.com/shanbay/gobay/extensions/redisext"
+)
+
+// TestClientEmitsBothSpans 端到端验证：APM 与 OTel 双开时，一条经由
+// RedisExt.Client(ctx) 执行的命令会在两套链路里各产出一个 span。
+//
+// 需要 testdata/config.yaml 里配置的 Redis 可达（与本包其他测试一致）。
+func TestClientEmitsBothSpans(t *testing.T) {
+	// 必须在 Init 之前设置：两个开关都是在 Init 里读环境变量的。
+	t.Setenv("APM_ENABLE", "true")
+	t.Setenv("OTEL_ENABLE", "true")
+
+	ext := &redisext.RedisExt{NS: "redis_"}
+	app, err := gobay.CreateApp("../../testdata/", "testing",
+		map[gobay.Key]gobay.Extension{"redis": ext})
+	if err != nil {
+		t.Fatalf("CreateApp 失败（Redis 不可达？）: %v", err)
+	}
+	t.Cleanup(func() { _ = app.Close() })
+
+	// 必须在 CreateApp 之后设置：OTEL_ENABLE=true 时 gobay 自身会在 app 初始化里
+	// 调用 otel.SetTracerProvider，先设会被它覆盖掉。
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSyncer(exp),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prev)
+		_ = tp.Shutdown(context.Background())
+	})
+
+	const key = "gobay-redisext-tracing-test"
+
+	_, apmSpans, _ := apmtest.WithTransaction(func(ctx context.Context) {
+		ctx, parent := tp.Tracer("test").Start(ctx, "parent")
+		defer parent.End()
+
+		if err := ext.Client(ctx).Set(key, "hello", 10*time.Second).Err(); err != nil {
+			t.Errorf("SET 失败: %v", err)
+			return
+		}
+		if _, err := ext.Client(ctx).Get(key).Result(); err != nil {
+			t.Errorf("GET 失败: %v", err)
+		}
+		ext.Client(ctx).Del(key)
+	})
+
+	var apmRedis int
+	for _, s := range apmSpans {
+		if s.Subtype == "redis" {
+			apmRedis++
+		}
+	}
+	if apmRedis == 0 {
+		t.Errorf("APM 侧没有 redis span，共 %d 个 span", len(apmSpans))
+	}
+
+	otelRedis := map[string]int{}
+	for _, s := range exp.GetSpans() {
+		if s.Name != "parent" {
+			otelRedis[s.Name]++
+		}
+	}
+	t.Logf("APM redis span 数=%d；OTel span=%v", apmRedis, otelRedis)
+	for _, want := range []string{"set", "get", "del"} {
+		if otelRedis[want] == 0 {
+			t.Errorf("OTel 侧缺少 %q span，实际 %v", want, otelRedis)
+		}
+	}
+}

--- a/observability/redisotelv6/tracing.go
+++ b/observability/redisotelv6/tracing.go
@@ -1,0 +1,183 @@
+// Package redisotelv6 为 go-redis v6 客户端提供 OpenTelemetry 链路追踪。
+//
+// go-redis v9 有官方的 redisotel，v6 没有：v6 的命令方法不接收 context，
+// 唯一能拿到 ctx 的地方是 (*redis.Client).WithContext 返回的每请求副本。本包在该
+// 副本上用 WrapProcess / WrapProcessPipeline 挂钩子，钩子闭包捕获 ctx —— 这与
+// go.elastic.co/apm/module/apmgoredis 的做法完全一致，因此两者可以叠加在同一个
+// 副本上，APM 与 OTel 各自产出 span，不必二选一。
+//
+// 之所以只能作用于每请求副本：WrapProcess 是 (c.process = fn(c.process)) 的原地
+// 修改。go-redis v6 的 Client 值嵌入 baseClient，clone() 走值拷贝，因此在副本上
+// 挂钩子不会影响基础 client、也不会跨请求累积。
+//
+// span 名与属性对齐 redisotel/v9，便于 v6 / v9 两条路径的数据在同一套看板里查询。
+package redisotelv6
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/go-redis/redis"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// TracerName 是本包创建 span 时使用的 instrumentation name。
+const TracerName = "github.com/shanbay/gobay/observability/redisotelv6"
+
+// 与 redisotel/v9 依赖的 rediscmd.AppendCmd 保持一致的截断口径。
+const (
+	numArgLimit = 32
+	argLenLimit = 64
+)
+
+// WrapClient 在 client 上挂 OTel 追踪钩子并返回它。
+//
+// 传入的必须是 (*redis.Client).WithContext(ctx) 返回的**每请求副本**（gobay 的
+// redisext.Client / cachext 的 withContext 都是这样拿的），否则钩子会挂到共享的
+// 基础 client 上并跨请求累积。
+//
+// 仅当 ctx 中已有「有效且被采样」的 span 上下文时才产出 span，与 entext 里
+// otelsql 的 SpanFilter 口径一致：既避免在无 trace 上下文时产生大量孤儿 root
+// span，也保证被采样的链路是完整的。这是与 redisotel/v9 的一处有意差异。
+func WrapClient(ctx context.Context, client *redis.Client) *redis.Client {
+	if client == nil {
+		return nil
+	}
+	if !shouldTrace(ctx) {
+		return client
+	}
+	tracer := otel.GetTracerProvider().Tracer(TracerName)
+
+	client.WrapProcess(func(oldProcess func(redis.Cmder) error) func(redis.Cmder) error {
+		return func(cmd redis.Cmder) error {
+			_, span := tracer.Start(ctx, cmd.Name(),
+				trace.WithSpanKind(trace.SpanKindClient),
+				trace.WithAttributes(
+					semconv.DBSystemRedis,
+					semconv.DBStatement(cmdString(cmd)),
+				),
+			)
+			defer span.End()
+
+			err := oldProcess(cmd)
+			recordError(span, err)
+			return err
+		}
+	})
+
+	client.WrapProcessPipeline(func(oldProcess func([]redis.Cmder) error) func([]redis.Cmder) error {
+		return func(cmds []redis.Cmder) error {
+			_, span := tracer.Start(ctx, "redis.pipeline "+pipelineSummary(cmds),
+				trace.WithSpanKind(trace.SpanKindClient),
+				trace.WithAttributes(
+					semconv.DBSystemRedis,
+					semconv.DBStatement(cmdsString(cmds)),
+					attribute.Int("db.redis.num_cmd", len(cmds)),
+				),
+			)
+			defer span.End()
+
+			err := oldProcess(cmds)
+			recordError(span, err)
+			return err
+		}
+	})
+
+	return client
+}
+
+// shouldTrace 与 entext 中 otelsql 的 SpanFilter 判据保持一致。
+func shouldTrace(ctx context.Context) bool {
+	sc := trace.SpanContextFromContext(ctx)
+	return sc.IsValid() && sc.IsSampled()
+}
+
+// recordError 不把 redis.Nil（键不存在）当成错误，与 redisotel/v9 一致。
+func recordError(span trace.Span, err error) {
+	if err == nil || err == redis.Nil {
+		return
+	}
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
+}
+
+func pipelineSummary(cmds []redis.Cmder) string {
+	switch len(cmds) {
+	case 0:
+		return "(empty)"
+	case 1:
+		return cmds[0].Name()
+	default:
+		return cmds[0].Name() + " ... " + cmds[len(cmds)-1].Name()
+	}
+}
+
+func cmdsString(cmds []redis.Cmder) string {
+	b := make([]byte, 0, 64)
+	for i, cmd := range cmds {
+		if i > numArgLimit {
+			break
+		}
+		if i > 0 {
+			b = append(b, '\n')
+		}
+		b = appendCmd(b, cmd)
+	}
+	return string(b)
+}
+
+func cmdString(cmd redis.Cmder) string {
+	return string(appendCmd(make([]byte, 0, 64), cmd))
+}
+
+func appendCmd(b []byte, cmd redis.Cmder) []byte {
+	for i, arg := range cmd.Args() {
+		if i > numArgLimit {
+			break
+		}
+		if i > 0 {
+			b = append(b, ' ')
+		}
+		b = appendArg(b, arg)
+	}
+	if err := cmd.Err(); err != nil && err != redis.Nil {
+		b = append(b, ": "...)
+		b = append(b, err.Error()...)
+	}
+	return b
+}
+
+func appendArg(b []byte, v interface{}) []byte {
+	switch v := v.(type) {
+	case nil:
+		return append(b, "<nil>"...)
+	case string:
+		return appendTruncated(b, v)
+	case []byte:
+		return appendTruncated(b, string(v))
+	case int:
+		return strconv.AppendInt(b, int64(v), 10)
+	case int64:
+		return strconv.AppendInt(b, v, 10)
+	case uint64:
+		return strconv.AppendUint(b, v, 10)
+	case float64:
+		return strconv.AppendFloat(b, v, 'f', -1, 64)
+	case bool:
+		return strconv.AppendBool(b, v)
+	default:
+		return appendTruncated(b, fmt.Sprint(v))
+	}
+}
+
+func appendTruncated(b []byte, s string) []byte {
+	if len(s) > argLenLimit {
+		s = s[:argLenLimit]
+	}
+	return append(b, s...)
+}

--- a/observability/redisotelv6/tracing_test.go
+++ b/observability/redisotelv6/tracing_test.go
@@ -1,0 +1,211 @@
+package redisotelv6
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-redis/redis"
+	"go.elastic.co/apm/apmtest"
+	"go.elastic.co/apm/module/apmgoredis"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// 指向一个必定连不上的端口：命令一定失败，但 Cmder 与 span 照常产生，
+// 因此这些测试不需要真实 Redis。
+func deadClient() *redis.Client {
+	return redis.NewClient(&redis.Options{
+		Addr:        "127.0.0.1:1",
+		MaxRetries:  0,
+		DialTimeout: 50 * time.Millisecond,
+	})
+}
+
+func recorder(t *testing.T) (*tracetest.InMemoryExporter, *sdktrace.TracerProvider) {
+	t.Helper()
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSyncer(exp),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	// WrapClient 从全局 TracerProvider 取 tracer，测试里必须把它设上，
+	// 否则 span 会进 no-op provider。
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prev)
+		_ = tp.Shutdown(context.Background())
+	})
+	return exp, tp
+}
+
+// sampledCtx 返回一个带「有效且被采样」span 的 ctx，并把该 span 结束掉，
+// 避免它混进断言。
+func sampledCtx(t *testing.T, tp *sdktrace.TracerProvider) context.Context {
+	t.Helper()
+	ctx, span := tp.Tracer("test").Start(context.Background(), "parent")
+	span.End()
+	return ctx
+}
+
+func TestWrapClientEmitsSpan(t *testing.T) {
+	exp, tp := recorder(t)
+	ctx := sampledCtx(t, tp)
+
+	base := deadClient()
+	t.Cleanup(func() { _ = base.Close() })
+
+	client := WrapClient(ctx, base.WithContext(ctx))
+	_ = client.Get("some-key").Err() // 必然失败，但 span 应当产生
+
+	var got trace.SpanKind
+	var found bool
+	var stmt string
+	for _, s := range exp.GetSpans() {
+		if s.Name == "parent" {
+			continue
+		}
+		found = true
+		got = s.SpanKind
+		if s.Name != "get" {
+			t.Errorf("span 名应为命令名 get，实际 %q", s.Name)
+		}
+		for _, a := range s.Attributes {
+			switch string(a.Key) {
+			case "db.system":
+				if a.Value.AsString() != "redis" {
+					t.Errorf("db.system 应为 redis，实际 %q", a.Value.AsString())
+				}
+			case "db.statement":
+				stmt = a.Value.AsString()
+			}
+		}
+		if s.Status.Code == 0 {
+			t.Error("连接失败时 span 状态应为 Error")
+		}
+	}
+	if !found {
+		t.Fatal("没有产出 redis span")
+	}
+	if got != trace.SpanKindClient {
+		t.Errorf("SpanKind 应为 client，实际 %v", got)
+	}
+	if !strings.HasPrefix(stmt, "get some-key") {
+		t.Errorf("db.statement 应以命令和参数开头，实际 %q", stmt)
+	}
+}
+
+// TestWrapClientSkipsWithoutSampledContext —— 无 trace 上下文时不产出 span，
+// 避免大量孤儿 root span。这是与 redisotel/v9 的有意差异。
+func TestWrapClientSkipsWithoutSampledContext(t *testing.T) {
+	exp, _ := recorder(t)
+
+	base := deadClient()
+	t.Cleanup(func() { _ = base.Close() })
+
+	ctx := context.Background()
+	client := WrapClient(ctx, base.WithContext(ctx))
+	_ = client.Get("some-key").Err()
+
+	if n := len(exp.GetSpans()); n != 0 {
+		t.Errorf("无采样上下文时不应产出 span，实际 %d 个", n)
+	}
+}
+
+// TestWrapClientDoesNotLeakToBaseClient 是本包最关键的安全前提：
+// 钩子必须只作用于 WithContext 返回的每请求副本。若它污染了基础 client，
+// 钩子会跨请求累积（既是内存泄漏，也会让 span 绑到过期的 ctx 上）。
+func TestWrapClientDoesNotLeakToBaseClient(t *testing.T) {
+	exp, tp := recorder(t)
+	ctx := sampledCtx(t, tp)
+
+	base := deadClient()
+	t.Cleanup(func() { _ = base.Close() })
+
+	// 连续包装 5 个每请求副本
+	for i := 0; i < 5; i++ {
+		_ = WrapClient(ctx, base.WithContext(ctx))
+	}
+	exp.Reset()
+
+	// 直接用基础 client 执行命令：不应产生任何 span
+	_ = base.Get("some-key").Err()
+	if n := len(exp.GetSpans()); n != 0 {
+		t.Fatalf("基础 client 被污染了：产出了 %d 个 span，说明钩子会跨请求累积", n)
+	}
+
+	// 而每请求副本仍应正常产出，且恰好一个（没有重复挂钩）
+	exp.Reset()
+	client := WrapClient(ctx, base.WithContext(ctx))
+	_ = client.Get("some-key").Err()
+	if n := len(exp.GetSpans()); n != 1 {
+		t.Fatalf("每请求副本应恰好产出 1 个 span，实际 %d 个", n)
+	}
+}
+
+func TestAppendArgTruncates(t *testing.T) {
+	long := strings.Repeat("x", 200)
+	got := string(appendArg(nil, long))
+	if len(got) != argLenLimit {
+		t.Errorf("长参数应截断到 %d 字节，实际 %d", argLenLimit, len(got))
+	}
+	if n := string(appendArg(nil, nil)); n != "<nil>" {
+		t.Errorf("nil 参数应渲染为 <nil>，实际 %q", n)
+	}
+	if n := string(appendArg(nil, 42)); n != "42" {
+		t.Errorf("int 参数应渲染为 42，实际 %q", n)
+	}
+}
+
+// TestCoexistsWithAPM 验证本包与 apmgoredis 叠加在同一个每请求副本上时，
+// 一条命令会在两套链路里各产出一个 span，而不是二选一。
+//
+// 这里的组合顺序与 redisext.Client / cachext 的 withContext 完全一致：
+// 先 apmgoredis.Wrap(...).WithContext(ctx).RedisClient()，再 WrapClient(ctx, ...)。
+// 命令打向死端口必然失败，但两个钩子都会照常建 span，因此无需真实 Redis。
+func TestCoexistsWithAPM(t *testing.T) {
+	exp, tp := recorder(t)
+
+	base := deadClient()
+	t.Cleanup(func() { _ = base.Close() })
+
+	_, apmSpans, _ := apmtest.WithTransaction(func(ctx context.Context) {
+		ctx, parent := tp.Tracer("test").Start(ctx, "parent")
+		defer parent.End()
+
+		client := apmgoredis.Wrap(base).WithContext(ctx).RedisClient()
+		client = WrapClient(ctx, client)
+		_ = client.Get("some-key").Err()
+	})
+
+	// —— APM 侧 ——
+	var apmRedisSpan bool
+	for _, s := range apmSpans {
+		t.Logf("APM span: name=%q type=%q subtype=%q", s.Name, s.Type, s.Subtype)
+		if s.Subtype == "redis" {
+			apmRedisSpan = true
+		}
+	}
+	if !apmRedisSpan {
+		t.Errorf("APM 侧没有产出 redis span，共 %d 个", len(apmSpans))
+	}
+
+	// —— OTel 侧 ——
+	var otelRedisSpan bool
+	for _, s := range exp.GetSpans() {
+		if s.Name == "parent" {
+			continue
+		}
+		t.Logf("OTel span: name=%q kind=%v", s.Name, s.SpanKind)
+		if s.Name == "get" {
+			otelRedisSpan = true
+		}
+	}
+	if !otelRedisSpan {
+		t.Errorf("OTel 侧没有产出 redis span，共 %d 个", len(exp.GetSpans()))
+	}
+}


### PR DESCRIPTION
配套 #743（那个解决 DB 侧）。这个 PR 解决 Redis 侧。

## 问题

`extensions/redisext` 和 `extensions/cachext/backend/redis`（都是 go-redis **v6** 版）只 import 了 `go.elastic.co/apm/module/apmgoredis`，**零 otel 引用**。OTel 插桩只存在于 v9 变体里。

后果：OTel 侧完全看不到 Redis 操作。排查慢请求时，应用的 Server span 表现为**没有子 span 的叶子节点**，看不出时间耗在哪。

## 为什么不迁 go-redis v9

**Elastic APM 没有 v9 模块** —— `apmgoredis` 只覆盖 v6/v7。迁到 `redisext/v9` 等于用 Redis 的 APM 数据换 OTel 数据，而 APM 目前不能关。

而且 `redisext` 用的是 `go-redis v6.15.9`（不是 v8），迁 v9 意味着每个命令都要加 ctx 参数 —— 单是 words-learning 一个服务就有 60 处调用点。

## 方案

新增 `observability/redisotelv6`，在 v6 上补 OTel，与 `apmgoredis` **并存**。

### ctx 怎么传进去

v6 的命令方法不接收 `context`，唯一能拿到 ctx 的地方是 `(*redis.Client).WithContext` 返回的**每请求副本**。本包在该副本上用 `WrapProcess` / `WrapProcessPipeline` 挂钩子、闭包捕获 ctx —— 这与 `apmgoredis` 的做法完全一致（见其 `contextClient.WithContext`），因此两者能叠加：`WrapProcess` 是 `c.process = fn(c.process)` 的组合式修改。

### 安全前提（已在 v6.15.9 源码核实）

在共享的基础 client 上挂钩子会**跨请求累积**，是内存泄漏 + span 绑到过期 ctx。核实结论：

- `Client` **值嵌入** `baseClient`，而 `process` 是 `baseClient` 的字段
- `clone()` 是 `cp := *c` 值拷贝 → 副本上 `WrapProcess` 不影响原 client
- `init()` 只做 `setProcessor(c.Process)`，**不重置** `process`

`TestWrapClientDoesNotLeakToBaseClient` 把这一点钉死了：连续包装 5 个副本后，用基础 client 执行命令必须零 span，且每请求副本恰好 1 个 span（没有重复挂钩）。

### span 约定

对齐 `redisotel/v9`，便于 v6 / v9 两条路径的数据在同一套看板里查询：命令名作 span 名、`SpanKind=Client`、`db.system=redis`、`db.statement` 限 **32 参数 × 每参数 64 字节**截断（与 `rediscmd.AppendCmd` 同口径）、`redis.Nil` 不记为错误。

**一处有意的差异**：仅当 ctx 已有「有效且被采样」的 span 上下文时才产出 span，与 `entext` 里 `otelsql` 的 `SpanFilter` 口径一致。理由是避免在无 trace 上下文时产生大量孤儿 root span —— Redis 调用频次远高于 SQL，这个量级差异不能忽略。

### 接入点

各一处，覆盖完整：

| 文件 | 位置 | 覆盖 |
| --- | --- | --- |
| `extensions/redisext/ext.go` | `Client(ctx)` | 所有 Redis 调用，含 `EvalLua` |
| `extensions/cachext/backend/redis/redis.go` | `withContext(ctx)` | 所有 Cache 操作 |

`apmgoredis` 那条链**一行未动**，APM 数据不受影响。

## 测试

**不依赖 Redis**（`observability/redisotelv6/tracing_test.go`，客户端指向死端口，命令必然失败但 span 照常产出）：

- `TestWrapClientEmitsSpan` —— span 名 / kind / `db.system` / `db.statement` / 错误状态
- `TestWrapClientSkipsWithoutSampledContext` —— 无采样上下文时零 span
- `TestWrapClientDoesNotLeakToBaseClient` —— 上面那条安全前提
- `TestAppendArgTruncates` —— 截断口径
- `TestCoexistsWithAPM` —— 与 `apmgoredis` 叠加，一条命令两个 span：
  ```
  APM  span: name="GET"  type="db"  subtype="redis"
  OTel span: name="get"  kind=client
  ```

**需要真实 Redis**（`extensions/redisext/tracing_test.go`，走完整的 `RedisExt.Client(ctx)`）：

- `TestClientEmitsBothSpans` —— 实测 APM 3 个 redis span，OTel `set`/`get`/`del` 各 1 个

> 这个测试里有个坑值得记一笔：`OTEL_ENABLE=true` 时 **gobay 自身会在 `CreateApp` 里调 `otel.SetTracerProvider`**，所以测试用的 TracerProvider 必须在 `CreateApp` **之后**设置，否则会被覆盖。

**四象限矩阵**（`observability/...` + `redisext` + `redisext/v9` + `cachext`，均 ok）：

| 组合 | 结果 |
| --- | --- |
| APM=true OTEL=true | ok |
| APM=true OTEL=false | ok |
| APM=false OTEL=true | ok |
| 都不设 | ok |

外加全模块 `go build ./...` / `go vet ./...` / `gofmt` 干净。

## 合入前建议关注

1. **span 量会显著放大**。Redis 调用频次远高于 SQL，这是比 #743 更猛的放大器。gobay 用的是 `sdktrace.NewBatchSpanProcessor(traceExporter)` 全默认参数（MaxQueueSize 2048），队列溢出时丢弃只在 `global.Debug` 里计数、业务侧无感。**灰度时务必同步调大 `OTEL_BSP_MAX_QUEUE_SIZE` 并监控 dropped。**
2. **`db.statement` 会带上参数值**（截断到 64 字节），即缓存 key 和 value 前 64 字节会进 trace。这是对齐 v9 的默认行为；若认为不合适，改 `WrapClient` 里 `semconv.DBStatement(cmdString(cmd))` 一处即可。
3. **每次 `Client(ctx)` 多两个闭包分配**。现有的 apmgoredis 已有同样量级的开销，但 Redis QPS 高，值得跑个 benchmark 确认。
4. **collector 侧需要先扩容**。otel-collector 目前单副本、`tail_sampling` decision_wait 10s，扩副本前需先上 `loadbalancing` exporter 做 trace ID 亲和。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4eaUum99JDRLs5wrJETp8
