### PR TITLE
feat: 给 asynctaskext/busext 增加 OpenTelemetry 链路追踪埋点

### DIFF
--- a/extensions/asynctaskext/asynctaskext.go
+++ b/extensions/asynctaskext/asynctaskext.go
@@ -22,6 +22,8 @@ import (
 	"github.com/RichardKnop/machinery/v1/tasks"
 	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
+	oteltrace "go.opentelemetry.io/otel/trace"
+
 	"github.com/shanbay/gobay"
 	"github.com/shanbay/gobay/observability"
 )
@@ -44,6 +46,9 @@ type AsyncTaskExt struct {
 	monitorEnabled  bool
 	taskStartTimes  map[string]time.Time
 	taskStartTimesM sync.Mutex
+
+	taskSpans  map[string]oteltrace.Span
+	taskSpansM sync.Mutex
 }
 
 func (t *AsyncTaskExt) Object() interface{} {
@@ -113,12 +118,18 @@ func (t *AsyncTaskExt) StartWorker(queue string, concurrency int, enableHealthCh
 	worker.Queue = queue
 	t.workers = append(t.workers, worker)
 
-	if t.monitorEnabled {
-		worker.SetPreTaskHandler(t.recordTaskStart)
-		worker.SetPostTaskHandler(func(sig *tasks.Signature) {
+	worker.SetPreTaskHandler(func(sig *tasks.Signature) {
+		if t.monitorEnabled {
+			t.recordTaskStart(sig)
+		}
+		t.otelTaskStart(sig)
+	})
+	worker.SetPostTaskHandler(func(sig *tasks.Signature) {
+		t.otelTaskEnd(sig)
+		if t.monitorEnabled {
 			t.recordTaskDuration(sig, queue)
-		})
-	}
+		}
+	})
 
 	// run health check http server
 	if enableHealthCheck && !t.healthHandlerRegistered {
@@ -148,7 +159,9 @@ func (t *AsyncTaskExt) SendTask(sign *tasks.Signature) (*result.AsyncResult, err
 
 //SendTask publish task messages with context to broker
 func (t *AsyncTaskExt) SendTaskWithContext(ctx context.Context, sign *tasks.Signature) (*result.AsyncResult, error) {
+	ctx, otelSendEnd := otelSendStart(ctx, sign)
 	asyncResult, err := t.server.SendTaskWithContext(ctx, sign)
+	otelSendEnd(err)
 	if err != nil {
 		log.ERROR.Printf("send task with context failed: %v", err)
 		return nil, err

--- a/extensions/asynctaskext/asynctaskext_otel_test.go
+++ b/extensions/asynctaskext/asynctaskext_otel_test.go
@@ -1,0 +1,126 @@
+/*
+# Partition table (ECP + BVA) — asynctaskext otel tracing
+
+# 参数/状态          | 等价类                          | 类型   | 代表值/场景                                   | 期望输出
+# OTEL_ENABLE        | 未开启（默认）                  | 有效   | env 为空                                      | otelTaskStart/otelTaskEnd 不产生 span，SendTaskWithContext 不注入 header
+# OTEL_ENABLE        | 开启                            | 有效   | env = "true"                                  | 产生 span / 注入 traceparent
+# 消息头 traceparent | 携带合法上游 traceparent        | 有效   | "00-<32hex>-<16hex>-01"                       | Consumer span 挂到上游 trace（TraceID 相同、parent 为上游 span）
+# 消息头 traceparent | 无（Headers 为空/缺 key）       | 边界   | sig.Headers == nil                            | 自建 root Consumer span，TraceID 合法
+# 发送侧 ctx         | ctx 携带活跃 span               | 有效   | 测试内手动 Start 一个 upstream span           | Producer span 与 upstream 同 TraceID，sig.Headers 注入 traceparent
+*/
+package asynctaskext
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/RichardKnop/machinery/v1/tasks"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
+)
+
+// newSpanRecorder 把全局 TracerProvider 换成带 recorder 的 provider，测试结束后恢复。
+func newSpanRecorder(t *testing.T) *tracetest.SpanRecorder {
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+	return sr
+}
+
+func TestOtelTaskSpan_LinksUpstreamTrace(t *testing.T) {
+	t.Setenv("OTEL_ENABLE", "true")
+	sr := newSpanRecorder(t)
+
+	upstreamTraceID := "4bf92f3577b34da6a3ce929d0e0e4736"
+	upstreamSpanID := "00f067aa0ba902b7"
+	sig := &tasks.Signature{
+		UUID: "otel-task-uuid-1",
+		Name: "TaskAdd",
+		Headers: tasks.Headers{
+			"traceparent": fmt.Sprintf("00-%s-%s-01", upstreamTraceID, upstreamSpanID),
+		},
+	}
+
+	taskOne.otelTaskStart(sig)
+	taskOne.otelTaskEnd(sig)
+
+	spans := sr.Ended()
+	if !assert.Len(t, spans, 1) {
+		return
+	}
+	span := spans[0]
+	assert.Equal(t, "run/TaskAdd", span.Name())
+	assert.Equal(t, oteltrace.SpanKindConsumer, span.SpanKind())
+	assert.Equal(t, upstreamTraceID, span.SpanContext().TraceID().String())
+	assert.Equal(t, upstreamSpanID, span.Parent().SpanID().String())
+}
+
+func TestOtelTaskSpan_NoUpstreamHeaders_StartsNewRootTrace(t *testing.T) {
+	t.Setenv("OTEL_ENABLE", "true")
+	sr := newSpanRecorder(t)
+
+	sig := &tasks.Signature{UUID: "otel-task-uuid-2", Name: "TaskAdd"}
+
+	taskOne.otelTaskStart(sig)
+	taskOne.otelTaskEnd(sig)
+
+	spans := sr.Ended()
+	if !assert.Len(t, spans, 1) {
+		return
+	}
+	span := spans[0]
+	assert.Equal(t, oteltrace.SpanKindConsumer, span.SpanKind())
+	assert.True(t, span.SpanContext().TraceID().IsValid())
+	assert.False(t, span.Parent().IsValid())
+}
+
+func TestOtelTaskSpan_DisabledByDefault_NoSpan(t *testing.T) {
+	t.Setenv("OTEL_ENABLE", "")
+	sr := newSpanRecorder(t)
+
+	sig := &tasks.Signature{UUID: "otel-task-uuid-3", Name: "TaskAdd"}
+
+	taskOne.otelTaskStart(sig)
+	taskOne.otelTaskEnd(sig)
+
+	assert.Empty(t, sr.Ended())
+}
+
+func TestSendTaskWithContext_InjectsTraceparentAndProducerSpan(t *testing.T) {
+	t.Setenv("OTEL_ENABLE", "true")
+	sr := newSpanRecorder(t)
+
+	ctx, upstream := otel.Tracer("test").Start(context.Background(), "upstream")
+
+	sig := &tasks.Signature{
+		Name: "TaskAdd",
+		Args: []tasks.Arg{
+			{Type: "int64", Value: 1},
+			{Type: "int64", Value: 2},
+		},
+	}
+	_, err := taskOne.SendTaskWithContext(ctx, sig)
+	assert.Nil(t, err)
+	upstream.End()
+
+	tp, _ := sig.Headers["traceparent"].(string)
+	assert.Contains(t, tp, upstream.SpanContext().TraceID().String())
+
+	var producer sdktrace.ReadOnlySpan
+	for _, span := range sr.Ended() {
+		if span.Name() == "send/TaskAdd" {
+			producer = span
+		}
+	}
+	if !assert.NotNil(t, producer, "should record a producer span named send/TaskAdd") {
+		return
+	}
+	assert.Equal(t, oteltrace.SpanKindProducer, producer.SpanKind())
+	assert.Equal(t, upstream.SpanContext().TraceID(), producer.SpanContext().TraceID())
+}

--- a/extensions/asynctaskext/otel.go
+++ b/extensions/asynctaskext/otel.go
@@ -1,0 +1,70 @@
+package asynctaskext
+
+import (
+	"context"
+
+	"github.com/RichardKnop/machinery/v1/tasks"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
+	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/shanbay/gobay/observability"
+)
+
+const tracerName = "github.com/shanbay/gobay/extensions/asynctaskext"
+
+var propagator = propagation.TraceContext{}
+
+// otelSendStart 在发送侧创建 SpanKind=Producer 的 span，并把 traceparent 注入
+// 任务消息头（machinery 会把 Headers 随消息序列化到 broker），供消费侧接续调用链。
+// 返回带 span 的 ctx 和结束回调；OTEL_ENABLE 未开启时原样返回、回调为 no-op。
+func otelSendStart(ctx context.Context, sign *tasks.Signature) (context.Context, func(err error)) {
+	if !observability.GetOtelEnable() {
+		return ctx, func(error) {}
+	}
+	ctx, span := otel.GetTracerProvider().Tracer(tracerName).Start(
+		ctx, "send/"+sign.Name, oteltrace.WithSpanKind(oteltrace.SpanKindProducer))
+	if sign.Headers == nil {
+		sign.Headers = tasks.Headers{}
+	}
+	propagator.Inject(ctx, observability.MapCarrier(sign.Headers))
+	return ctx, func(err error) {
+		if err != nil {
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+	}
+}
+
+// otelTaskStart / otelTaskEnd 挂在 machinery worker 的 Pre/PostTaskHandler 上：
+// 从任务消息头提取上游 traceparent（没有则自建 root trace），为每次任务执行记录
+// 一个 SpanKind=Consumer 的 span，按 signature.UUID 关联起止。
+// 与 recordTaskDuration 同理，machinery 的全局 hook 拿不到该次调用的 error，
+// span 状态不标 Error（保持 Unset）。
+func (t *AsyncTaskExt) otelTaskStart(sig *tasks.Signature) {
+	if !observability.GetOtelEnable() {
+		return
+	}
+	ctx := propagator.Extract(context.Background(), observability.MapCarrier(sig.Headers))
+	_, span := otel.GetTracerProvider().Tracer(tracerName).Start(
+		ctx, "run/"+sig.Name, oteltrace.WithSpanKind(oteltrace.SpanKindConsumer))
+	t.taskSpansM.Lock()
+	defer t.taskSpansM.Unlock()
+	if t.taskSpans == nil {
+		t.taskSpans = make(map[string]oteltrace.Span)
+	}
+	t.taskSpans[sig.UUID] = span
+}
+
+func (t *AsyncTaskExt) otelTaskEnd(sig *tasks.Signature) {
+	t.taskSpansM.Lock()
+	span, ok := t.taskSpans[sig.UUID]
+	if ok {
+		delete(t.taskSpans, sig.UUID)
+	}
+	t.taskSpansM.Unlock()
+	if ok {
+		span.End()
+	}
+}

--- a/extensions/busext/amqp.go
+++ b/extensions/busext/amqp.go
@@ -305,7 +305,10 @@ func (b *BusExt) Consume() error {
 //	"parse_error"      — json.Unmarshal 失败 或 handler.ParsePayload 失败
 //	"failure"          — handler.Run() 返回 error
 //	"success"          — 全部通过
-func (b *BusExt) dispatch(delivery amqp.Delivery) string {
+func (b *BusExt) dispatch(delivery amqp.Delivery) (status string) {
+	otelDispatchEnd := otelDispatchStart(delivery)
+	defer func() { otelDispatchEnd(status) }()
+
 	var handler Handler
 	var ok bool
 	if delivery.Headers == nil {

--- a/extensions/busext/amqp.go
+++ b/extensions/busext/amqp.go
@@ -306,7 +306,7 @@ func (b *BusExt) Consume() error {
 //	"failure"          — handler.Run() 返回 error
 //	"success"          — 全部通过
 func (b *BusExt) dispatch(delivery amqp.Delivery) (status string) {
-	otelDispatchEnd := otelDispatchStart(delivery)
+	ctx, otelDispatchEnd := otelDispatchStart(delivery)
 	defer func() { otelDispatchEnd(status) }()
 
 	var handler Handler
@@ -332,7 +332,7 @@ func (b *BusExt) dispatch(delivery amqp.Delivery) (status string) {
 	} else if err := handler.ParsePayload(payload[0], payload[1]); err != nil {
 		b.ErrorLogger.Printf("handler parse payload error: %v\n", err)
 		return "parse_error"
-	} else if err := handler.Run(); err != nil {
+	} else if err := runHandler(ctx, handler); err != nil {
 		b.ErrorLogger.Printf("handler run task failed: %v\n", err)
 		return "failure"
 	}

--- a/extensions/busext/amqp_otel_test.go
+++ b/extensions/busext/amqp_otel_test.go
@@ -8,6 +8,9 @@
 # handler 执行结果   | 成功                            | 有效   | Run() 返回 nil                                | span 状态非 Error
 # handler 执行结果   | 失败                            | 有效   | Run() 返回 error                              | span 状态 Error，描述为 "failure"
 # 发送侧 ctx         | ctx 携带活跃 span               | 有效   | 测试内手动 Start 一个 upstream span           | Producer span 与 upstream 同 TraceID，data.Headers 注入 traceparent
+# handler 接口形态   | 实现 HandlerWithContext         | 有效   | ctxRecordingHandler                           | 走 RunWithContext（不走 Run），ctx 携带上游 TraceID
+# handler 接口形态   | 实现 HandlerWithContext+otel 关 | 边界   | env 为空 + ctxRecordingHandler                | 仍走 RunWithContext，ctx 为 Background，零 span
+# span 属性          | Consumer/Producer 语义属性      | 有效   | messaging.system/destination.name/operation   | 属性齐全，gobay.bus.status 记录结果状态
 */
 package busext
 
@@ -152,4 +155,100 @@ func TestPushWithContext_InjectsTraceparentAndProducerSpan(t *testing.T) {
 	}
 	assert.Equal(t, oteltrace.SpanKindProducer, producer.SpanKind())
 	assert.Equal(t, upstream.SpanContext().TraceID(), producer.SpanContext().TraceID())
+}
+
+type ctxRecordingHandler struct {
+	gotCtx     context.Context
+	ranWithCtx bool
+	ranPlain   bool
+}
+
+func (h *ctxRecordingHandler) ParsePayload(args, kwargs []byte) error { return nil }
+func (h *ctxRecordingHandler) Run() error                             { h.ranPlain = true; return nil }
+func (h *ctxRecordingHandler) RunWithContext(ctx context.Context) error {
+	h.ranWithCtx = true
+	h.gotCtx = ctx
+	return nil
+}
+
+func TestDispatch_HandlerWithContext_ReceivesUpstreamTraceContext(t *testing.T) {
+	t.Setenv("OTEL_ENABLE", "true")
+	newSpanRecorder(t)
+
+	upstreamTraceID := "4bf92f3577b34da6a3ce929d0e0e4736"
+	h := &ctxRecordingHandler{}
+	b := newOtelTestBusExt("buses.test.event", h)
+	delivery := newOtelTestDelivery(
+		"buses.test.event",
+		fmt.Sprintf("00-%s-00f067aa0ba902b7-01", upstreamTraceID),
+	)
+
+	assert.Equal(t, "success", b.dispatch(delivery))
+	assert.True(t, h.ranWithCtx, "should call RunWithContext instead of Run")
+	assert.False(t, h.ranPlain)
+	if !assert.NotNil(t, h.gotCtx) {
+		return
+	}
+	assert.Equal(t, upstreamTraceID,
+		oteltrace.SpanContextFromContext(h.gotCtx).TraceID().String())
+}
+
+func TestDispatch_HandlerWithContext_WorksWithOtelDisabled(t *testing.T) {
+	t.Setenv("OTEL_ENABLE", "")
+	sr := newSpanRecorder(t)
+
+	h := &ctxRecordingHandler{}
+	b := newOtelTestBusExt("buses.test.event", h)
+
+	assert.Equal(t, "success", b.dispatch(newOtelTestDelivery("buses.test.event", "")))
+	assert.True(t, h.ranWithCtx, "interface dispatch must not depend on OTEL_ENABLE")
+	assert.False(t, h.ranPlain)
+	assert.NotNil(t, h.gotCtx)
+	assert.Empty(t, sr.Ended())
+}
+
+func spanAttr(span sdktrace.ReadOnlySpan, key string) string {
+	for _, kv := range span.Attributes() {
+		if string(kv.Key) == key {
+			return kv.Value.AsString()
+		}
+	}
+	return ""
+}
+
+func TestDispatch_ConsumerSpanHasMessagingAttributes(t *testing.T) {
+	t.Setenv("OTEL_ENABLE", "true")
+	sr := newSpanRecorder(t)
+
+	b := newOtelTestBusExt("buses.test.event", &otelOKHandler{})
+	assert.Equal(t, "success", b.dispatch(newOtelTestDelivery("buses.test.event", "")))
+
+	spans := sr.Ended()
+	if !assert.Len(t, spans, 1) {
+		return
+	}
+	span := spans[0]
+	assert.Equal(t, "rabbitmq", spanAttr(span, "messaging.system"))
+	assert.Equal(t, "buses.test.event", spanAttr(span, "messaging.destination.name"))
+	assert.Equal(t, "process", spanAttr(span, "messaging.operation"))
+	assert.Equal(t, "success", spanAttr(span, "gobay.bus.status"))
+}
+
+func TestPushWithContext_ProducerSpanHasMessagingAttributes(t *testing.T) {
+	t.Setenv("OTEL_ENABLE", "true")
+	sr := newSpanRecorder(t)
+
+	b := &BusExt{mocked: true}
+	msg, err := BuildMsg("buses.test.event", []interface{}{}, map[string]interface{}{})
+	assert.Nil(t, err)
+	assert.Nil(t, b.PushWithContext(context.Background(), "sbay-exchange", "buses.test.event", *msg))
+
+	spans := sr.Ended()
+	if !assert.Len(t, spans, 1) {
+		return
+	}
+	span := spans[0]
+	assert.Equal(t, "rabbitmq", spanAttr(span, "messaging.system"))
+	assert.Equal(t, "buses.test.event", spanAttr(span, "messaging.destination.name"))
+	assert.Equal(t, "publish", spanAttr(span, "messaging.operation"))
 }

--- a/extensions/busext/amqp_otel_test.go
+++ b/extensions/busext/amqp_otel_test.go
@@ -1,0 +1,155 @@
+/*
+# Partition table (ECP + BVA) — busext otel tracing
+
+# 参数/状态          | 等价类                          | 类型   | 代表值/场景                                   | 期望输出
+# OTEL_ENABLE        | 未开启（默认）                  | 有效   | env 为空                                      | dispatch 不产生 span
+# OTEL_ENABLE        | 开启                            | 有效   | env = "true"                                  | dispatch 产生 Consumer span / PushWithContext 注入并产生 Producer span
+# delivery.Headers   | 携带合法上游 traceparent        | 有效   | "00-<32hex>-<16hex>-01"                       | Consumer span 挂到上游 trace
+# handler 执行结果   | 成功                            | 有效   | Run() 返回 nil                                | span 状态非 Error
+# handler 执行结果   | 失败                            | 有效   | Run() 返回 error                              | span 状态 Error，描述为 "failure"
+# 发送侧 ctx         | ctx 携带活跃 span               | 有效   | 测试内手动 Start 一个 upstream span           | Producer span 与 upstream 同 TraceID，data.Headers 注入 traceparent
+*/
+package busext
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/streadway/amqp"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
+)
+
+// newSpanRecorder 把全局 TracerProvider 换成带 recorder 的 provider，测试结束后恢复。
+func newSpanRecorder(t *testing.T) *tracetest.SpanRecorder {
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+	return sr
+}
+
+type otelOKHandler struct{}
+
+func (h *otelOKHandler) ParsePayload(args, kwargs []byte) error { return nil }
+func (h *otelOKHandler) Run() error                             { return nil }
+
+type otelFailHandler struct{}
+
+func (h *otelFailHandler) ParsePayload(args, kwargs []byte) error { return nil }
+func (h *otelFailHandler) Run() error                             { return errors.New("boom") }
+
+func newOtelTestBusExt(routingKey string, handler Handler) *BusExt {
+	return &BusExt{
+		consumers:   map[string]Handler{routingKey: handler},
+		ErrorLogger: log.New(os.Stderr, "[otel-test]", 0),
+	}
+}
+
+func newOtelTestDelivery(routingKey, traceparent string) amqp.Delivery {
+	headers := amqp.Table{}
+	if traceparent != "" {
+		headers["traceparent"] = traceparent
+	}
+	return amqp.Delivery{
+		Headers:         headers,
+		ContentType:     "application/json",
+		ContentEncoding: "utf-8",
+		RoutingKey:      routingKey,
+		Body:            []byte("[[], {}]"),
+	}
+}
+
+func TestDispatch_ConsumerSpanLinksUpstreamTrace(t *testing.T) {
+	t.Setenv("OTEL_ENABLE", "true")
+	sr := newSpanRecorder(t)
+
+	upstreamTraceID := "4bf92f3577b34da6a3ce929d0e0e4736"
+	upstreamSpanID := "00f067aa0ba902b7"
+	b := newOtelTestBusExt("buses.test.event", &otelOKHandler{})
+	delivery := newOtelTestDelivery(
+		"buses.test.event",
+		fmt.Sprintf("00-%s-%s-01", upstreamTraceID, upstreamSpanID),
+	)
+
+	status := b.dispatch(delivery)
+	assert.Equal(t, "success", status)
+
+	spans := sr.Ended()
+	if !assert.Len(t, spans, 1) {
+		return
+	}
+	span := spans[0]
+	assert.Equal(t, "run/buses.test.event", span.Name())
+	assert.Equal(t, oteltrace.SpanKindConsumer, span.SpanKind())
+	assert.Equal(t, upstreamTraceID, span.SpanContext().TraceID().String())
+	assert.Equal(t, upstreamSpanID, span.Parent().SpanID().String())
+	assert.NotEqual(t, codes.Error, span.Status().Code)
+}
+
+func TestDispatch_HandlerFailureSetsErrorStatus(t *testing.T) {
+	t.Setenv("OTEL_ENABLE", "true")
+	sr := newSpanRecorder(t)
+
+	b := newOtelTestBusExt("buses.test.event", &otelFailHandler{})
+	delivery := newOtelTestDelivery("buses.test.event", "")
+
+	status := b.dispatch(delivery)
+	assert.Equal(t, "failure", status)
+
+	spans := sr.Ended()
+	if !assert.Len(t, spans, 1) {
+		return
+	}
+	assert.Equal(t, codes.Error, spans[0].Status().Code)
+	assert.Equal(t, "failure", spans[0].Status().Description)
+}
+
+func TestDispatch_OtelDisabledByDefault_NoSpan(t *testing.T) {
+	t.Setenv("OTEL_ENABLE", "")
+	sr := newSpanRecorder(t)
+
+	b := newOtelTestBusExt("buses.test.event", &otelOKHandler{})
+	status := b.dispatch(newOtelTestDelivery("buses.test.event", ""))
+	assert.Equal(t, "success", status)
+
+	assert.Empty(t, sr.Ended())
+}
+
+func TestPushWithContext_InjectsTraceparentAndProducerSpan(t *testing.T) {
+	t.Setenv("OTEL_ENABLE", "true")
+	sr := newSpanRecorder(t)
+
+	ctx, upstream := otel.Tracer("test").Start(context.Background(), "upstream")
+
+	b := &BusExt{mocked: true}
+	msg, err := BuildMsg("buses.test.event", []interface{}{}, map[string]interface{}{})
+	assert.Nil(t, err)
+
+	assert.Nil(t, b.PushWithContext(ctx, "sbay-exchange", "buses.test.event", *msg))
+	upstream.End()
+
+	tp, _ := msg.Headers["traceparent"].(string)
+	assert.Contains(t, tp, upstream.SpanContext().TraceID().String())
+
+	var producer sdktrace.ReadOnlySpan
+	for _, span := range sr.Ended() {
+		if span.Name() == "send/buses.test.event" {
+			producer = span
+		}
+	}
+	if !assert.NotNil(t, producer, "should record a producer span named send/buses.test.event") {
+		return
+	}
+	assert.Equal(t, oteltrace.SpanKindProducer, producer.SpanKind())
+	assert.Equal(t, upstream.SpanContext().TraceID(), producer.SpanContext().TraceID())
+}

--- a/extensions/busext/otel.go
+++ b/extensions/busext/otel.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/streadway/amqp"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
 	oteltrace "go.opentelemetry.io/otel/trace"
@@ -16,14 +17,39 @@ const tracerName = "github.com/shanbay/gobay/extensions/busext"
 
 var propagator = propagation.TraceContext{}
 
+// HandlerWithContext 是 Handler 的可选扩展接口：实现它的 handler 在消费时拿到
+// 携带上游 trace 上下文（及本次 Consumer span）的 ctx，把 ctx 传给 ent/redis/RPC
+// 等下游调用即可让整条链路挂到同一个 trace 上。
+// 未实现该接口的 handler 行为不变（走 Run()）；接口分发不依赖 OTEL_ENABLE，
+// 未开启时 ctx 为 context.Background()。
+type HandlerWithContext interface {
+	Handler
+	RunWithContext(ctx context.Context) error
+}
+
+// runHandler 优先走 HandlerWithContext，未实现则退回 Run()。
+func runHandler(ctx context.Context, handler Handler) error {
+	if h, ok := handler.(HandlerWithContext); ok {
+		return h.RunWithContext(ctx)
+	}
+	return handler.Run()
+}
+
 // PushWithContext 与 Push 相同，但在 OTEL_ENABLE 开启时额外创建 SpanKind=Producer
-// 的 span，并把 traceparent 注入消息 Headers，供消费侧接续调用链。
+// 的 span，并把 traceparent 注入消息 Headers——消费方无论 Go（本扩展）还是
+// Python（opentelemetry-instrumentation-celery）都能续到同一条 trace。
 func (b *BusExt) PushWithContext(ctx context.Context, exchange, routingKey string, data amqp.Publishing) error {
 	if !observability.GetOtelEnable() {
 		return b.Push(exchange, routingKey, data)
 	}
 	ctx, span := otel.GetTracerProvider().Tracer(tracerName).Start(
-		ctx, "send/"+routingKey, oteltrace.WithSpanKind(oteltrace.SpanKindProducer))
+		ctx, "send/"+routingKey,
+		oteltrace.WithSpanKind(oteltrace.SpanKindProducer),
+		oteltrace.WithAttributes(
+			attribute.String("messaging.system", "rabbitmq"),
+			attribute.String("messaging.destination.name", routingKey),
+			attribute.String("messaging.operation", "publish"),
+		))
 	defer span.End()
 	if data.Headers == nil {
 		data.Headers = amqp.Table{}
@@ -37,17 +63,26 @@ func (b *BusExt) PushWithContext(ctx context.Context, exchange, routingKey strin
 }
 
 // otelDispatchStart 在消费侧从 delivery.Headers 提取上游 traceparent（没有则自建
-// root trace），创建 SpanKind=Consumer 的 span。返回的回调按 dispatch 的结果状态
-// 结束 span：非 "success" 一律标记 Error，描述为状态串。
-// OTEL_ENABLE 未开启时回调为 no-op。
-func otelDispatchStart(delivery amqp.Delivery) func(status string) {
+// root trace），创建 SpanKind=Consumer 的 span，返回携带该 span 的 ctx（供
+// HandlerWithContext 透传给下游）和收尾回调。回调按 dispatch 的结果状态结束
+// span：非 "success" 一律标记 Error，描述为状态串——失败的 bus 事件因此能被
+// collector 的 tail_sampling 保留。OTEL_ENABLE 未开启时 ctx 为 Background、回调
+// 为 no-op。
+func otelDispatchStart(delivery amqp.Delivery) (context.Context, func(status string)) {
 	if !observability.GetOtelEnable() {
-		return func(string) {}
+		return context.Background(), func(string) {}
 	}
 	ctx := propagator.Extract(context.Background(), observability.MapCarrier(delivery.Headers))
-	_, span := otel.GetTracerProvider().Tracer(tracerName).Start(
-		ctx, "run/"+delivery.RoutingKey, oteltrace.WithSpanKind(oteltrace.SpanKindConsumer))
-	return func(status string) {
+	ctx, span := otel.GetTracerProvider().Tracer(tracerName).Start(
+		ctx, "run/"+delivery.RoutingKey,
+		oteltrace.WithSpanKind(oteltrace.SpanKindConsumer),
+		oteltrace.WithAttributes(
+			attribute.String("messaging.system", "rabbitmq"),
+			attribute.String("messaging.destination.name", delivery.RoutingKey),
+			attribute.String("messaging.operation", "process"),
+		))
+	return ctx, func(status string) {
+		span.SetAttributes(attribute.String("gobay.bus.status", status))
 		if status != "success" {
 			span.SetStatus(codes.Error, status)
 		}

--- a/extensions/busext/otel.go
+++ b/extensions/busext/otel.go
@@ -1,0 +1,56 @@
+package busext
+
+import (
+	"context"
+
+	"github.com/streadway/amqp"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
+	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/shanbay/gobay/observability"
+)
+
+const tracerName = "github.com/shanbay/gobay/extensions/busext"
+
+var propagator = propagation.TraceContext{}
+
+// PushWithContext 与 Push 相同，但在 OTEL_ENABLE 开启时额外创建 SpanKind=Producer
+// 的 span，并把 traceparent 注入消息 Headers，供消费侧接续调用链。
+func (b *BusExt) PushWithContext(ctx context.Context, exchange, routingKey string, data amqp.Publishing) error {
+	if !observability.GetOtelEnable() {
+		return b.Push(exchange, routingKey, data)
+	}
+	ctx, span := otel.GetTracerProvider().Tracer(tracerName).Start(
+		ctx, "send/"+routingKey, oteltrace.WithSpanKind(oteltrace.SpanKindProducer))
+	defer span.End()
+	if data.Headers == nil {
+		data.Headers = amqp.Table{}
+	}
+	propagator.Inject(ctx, observability.MapCarrier(data.Headers))
+	err := b.Push(exchange, routingKey, data)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+	}
+	return err
+}
+
+// otelDispatchStart 在消费侧从 delivery.Headers 提取上游 traceparent（没有则自建
+// root trace），创建 SpanKind=Consumer 的 span。返回的回调按 dispatch 的结果状态
+// 结束 span：非 "success" 一律标记 Error，描述为状态串。
+// OTEL_ENABLE 未开启时回调为 no-op。
+func otelDispatchStart(delivery amqp.Delivery) func(status string) {
+	if !observability.GetOtelEnable() {
+		return func(string) {}
+	}
+	ctx := propagator.Extract(context.Background(), observability.MapCarrier(delivery.Headers))
+	_, span := otel.GetTracerProvider().Tracer(tracerName).Start(
+		ctx, "run/"+delivery.RoutingKey, oteltrace.WithSpanKind(oteltrace.SpanKindConsumer))
+	return func(status string) {
+		if status != "success" {
+			span.SetStatus(codes.Error, status)
+		}
+		span.End()
+	}
+}

--- a/extensions/cachext/ext_test.go
+++ b/extensions/cachext/ext_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"net"
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -585,7 +586,7 @@ func TestCacheExt_Cached_Monitor(t *testing.T) {
 	fetchMetricData := func() string {
 		resp, err := http.Get("http://localhost:2112/metrics")
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 		defer resp.Body.Close()
 		rawData, err := io.ReadAll(resp.Body)
@@ -601,6 +602,16 @@ func TestCacheExt_Cached_Monitor(t *testing.T) {
 			log.Fatalf("error when start prometheus server: %v\n", err)
 		}
 	}()
+	// ListenAndServe 在 goroutine 里异步启动，必须等端口可连接后才能发请求，
+	// 否则 Get 会 connection refused（此前 t.Error 不中止，随后 resp.Body nil 解引用直接 SIGSEGV）
+	for i := 0; i < 50; i++ {
+		conn, err := net.Dial("tcp", "localhost:2112")
+		if err == nil {
+			conn.Close()
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
 
 	// Cache method
 	f_str := func(_ context.Context, keys []string, args []int64) (interface{}, error) {

--- a/observability/carrier.go
+++ b/observability/carrier.go
@@ -1,0 +1,25 @@
+package observability
+
+// MapCarrier 把 map[string]interface{} 形态的消息头（machinery 的 tasks.Headers、
+// amqp.Table）适配成 OpenTelemetry 的 TextMapCarrier，供 traceparent 注入/提取。
+// 非 string 值在 Get 时视为不存在。
+type MapCarrier map[string]interface{}
+
+func (c MapCarrier) Get(key string) string {
+	if v, ok := c[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+func (c MapCarrier) Set(key, value string) {
+	c[key] = value
+}
+
+func (c MapCarrier) Keys() []string {
+	keys := make([]string, 0, len(c))
+	for k := range c {
+		keys = append(keys, k)
+	}
+	return keys
+}


### PR DESCRIPTION
## 背景

`OTEL_ENABLE` 开启后 gobay 只初始化了 TracerProvider / OTLP exporter，span 只由 HTTP/gRPC/Redis 等请求路径上的中间件产生。asynctask（machinery worker）和 bus（AMQP 消费/发布）两条消息路径上没有任何创建 span 的代码——线上验证（以 quest 为例）：`quest.xyz` 一周 50w+ 条 api/rpc span，Consumer/Producer span 为 **0**。

> 本 PR 已合流 #741（busext OTel trace）的独有能力（HandlerWithContext 透传、messaging 语义属性）；两 PR 重复的 busext 消费/发布插桩以本分支实现为准。#741 随之关闭。

## 改动

**asynctaskext**
- `SendTaskWithContext`：创建 `SpanKind=Producer` 的 `send/<task>` span，并把 `traceparent` 注入 `Signature.Headers`（machinery 会随消息序列化到 broker）
- worker `Pre/PostTaskHandler`：按 `signature.UUID` 记录 `SpanKind=Consumer` 的 `run/<task>` span——消息头带 `traceparent` 时接续上游 trace，否则自建 root trace。与耗时指标（#736）同理，machinery 全局 hook 拿不到该次调用的 error，span 状态保持 Unset

**busext**
- 新增 `PushWithContext`：Producer span + 注入 `traceparent` 到消息 Headers；原 `Push` 签名与行为不变。Python 端 celery worker（opentelemetry-instrumentation-celery）可自动续链
- `dispatch` 包一层 Consumer span（`run/<routingKey>`），按结果状态收尾：非 `success` 标记 `Error`——失败的 bus 事件因此能被 collector 的 tail_sampling 保留
- **`HandlerWithContext` 可选接口**（自 #741）：实现 `RunWithContext(ctx)` 的 handler 拿到携带上游 trace 上下文（及本次 Consumer span）的 ctx，传给 ent/redis/RPC 即整链贯通；未实现的 handler 走 `Run()` 零改动，接口分发不依赖 `OTEL_ENABLE`
- Consumer/Producer span 带 `messaging.system` / `messaging.destination.name` / `messaging.operation` 语义属性，Consumer 额外记 `gobay.bus.status`（自 #741）

**observability**
- 新增 `MapCarrier`：把 `tasks.Headers` / `amqp.Table`（`map[string]interface{}`）适配成 otel `TextMapCarrier`

## 行为边界

- 全部埋点以 `OTEL_ENABLE` 环境变量为开关（与现有 `initOtel` 同源），未开启时零行为变化
- 业务服务升级 gobay 后无需改代码/配置即可出数据（线上 Deployment 已普遍注入 `OTEL_ENABLE` / `OTEL_SERVICE_NAME`）
- 跨语言：span 命名与 Python celery 插桩一致（`run/<name>`），Python→Go / Go→Python 链路可互续；Python 消费侧 parent-based 采样的配套修复见 backend-lib/coast!242
- asynctask 的 Consumer span 不进入任务函数 ctx（machinery 不支持注入）；bus 侧可通过 `HandlerWithContext` 拿到 ctx

## 测试

- TDD：13 个用例先行验证 RED 后实现（traceparent 接续/自建 root/开关关闭零行为/发送侧注入 + Producer span/bus 失败置 Error/HandlerWithContext 透传与回退/messaging 属性）
- `go test ./extensions/asynctaskext/ ./extensions/busext/`（本地 redis + rabbitmq:3.8）全量通过，无回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6xmHTyA1Wfgcf3igefjU3