### PR TITLE
feat: 四个 redis 扩展入口补齐连接池与超时默认值

### DIFF
--- a/app.go
+++ b/app.go
@@ -167,6 +167,28 @@ func CreateApp(rootPath string, env string, exts map[Key]Extension) (*Applicatio
 	return app, nil
 }
 
+// NormalizeUnderscoreKeys 让带下划线的配置键名也能被 Unmarshal 匹配到。
+//
+// viper 的 Unmarshal 底层是 mapstructure，它只做大小写折叠、不做下划线归一化：
+// 结构体字段 PoolSize 能匹配 poolsize / POOLSIZE，但匹配不上 pool_size。历史上
+// <NS>pool_size 这样的写法会被静默忽略，对应字段保持零值，排查起来很费劲。
+// 这里在 Unmarshal 之前把带下划线的键补一份去掉下划线的写法。
+//
+// 两种写法并存时以**不带下划线的**为准。交给 mapstructure 自行处理的话，两个键
+// 都会匹配上同一个字段，最终哪个生效取决于 map 的迭代顺序，是不确定的。
+//
+// 必须在 SetDefault 之前调用，否则 IsSet 会因为默认值而恒为真，感知不到用户实际
+// 配的是哪种写法。
+func NormalizeUnderscoreKeys(config *viper.Viper) {
+	for _, key := range config.AllKeys() {
+		flat := strings.ReplaceAll(key, "_", "")
+		if flat == key || config.IsSet(flat) {
+			continue
+		}
+		config.Set(flat, config.Get(key))
+	}
+}
+
 func GetConfigByPrefix(config *viper.Viper, prefix string, trimPrefix bool) *viper.Viper {
 	subConfig := viper.New()
 	for k, v := range config.AllSettings() {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,26 @@
+# 1.2.10 (2026-09-03)
+
+- **行为变更：四个 redis 扩展入口（`cachext` 的 v6/v9 backend、`redisext` 的 v6/v9）现在都带连接池与超时默认值**，业务项目无需任何配置即可生效：
+
+  | 参数           | 默认值 | 配置键（v6 / v9）                         | go-redis 原默认值                 |
+  | -------------- | ------ | ----------------------------------------- | --------------------------------- |
+  | 连接池上限     | 100    | `<NS>poolsize`                            | `10 × NumCPU` / `10 × GOMAXPROCS` |
+  | 读超时         | 200ms  | `<NS>readtimeout`                         | 3s                                |
+  | 取连接排队超时 | 100ms  | `<NS>pooltimeout`                         | ReadTimeout + 1s                  |
+  | 空闲回收       | 2m     | `<NS>idletimeout` / `<NS>connmaxidletime` | 5m / 30m                          |
+
+- `PoolSize` 默认值由 1.2.9 的 20 提高到 **100**。20 过于保守，会限制正常流量下的连接需求；100 是按实测单池峰值取的兜底上限
+- **新增三项超时默认值。** go-redis 的原默认值（读 3 秒、排队 4 秒）长于典型在线链路的上游预算，等于把请求堆积留在自己进程里。v6 尤其需要：它的连接读写与排队都不接受 `context`，上游超时管不到 redis 调用，这三项是唯一能限制单连接占用时长的闸。v9 虽然 `deadline` 取 `min(ctx.Deadline(), now+ReadTimeout)`，但 ReadTimeout 作为静态上界仍然必要——没有 deadline 的调用（离线任务、cronjob）否则会落在 3 秒上
+- **空闲回收收敛到 2 分钟。** v9 的 `ConnMaxIdleTime` 默认 30 分钟，一次瞬时并发建出来的连接会被留到半小时后才回收，池子只涨不落
+- 需要放宽的服务显式配置对应键即可覆盖；`<NS>poolsize: 0` 仍然回到 go-redis 自己的默认值
+- `redisext` 补上首批带断言的测试（此前只有无断言的 Example 测试）
+
+- **配置键名现在支持下划线写法**：`redis_poolsize` 与 `redis_pool_size` 都生效。mapstructure 只做大小写折叠、不做下划线归一化，此前后者会被静默忽略；新增的 `gobay.NormalizeUnderscoreKeys` 在 `Unmarshal` 前补齐。两种写法并存时以**不带下划线的**为准——交给 mapstructure 自行处理的话，哪个生效取决于 map 迭代顺序，是不确定的。
+
+⚠️ 时间类参数必须带单位：`200ms` 正确，`200` 会被当成 200 纳秒。
+
+⚠️ `redisext` 的 `<NS>host` 键**不生效**（`redis.Options` 只有 `Addr` 没有 `Host`，mapstructure 找不到字段会静默跳过，go-redis 随后 fallback 到 `localhost:6379`）。本版本未改动这一行为，请显式使用 `<NS>addr`。**`cachext` 不受影响**——它的 redis backend 有 `Addr` 为空时回落到 `<NS>host` 的兼容代码，`cache_host` 照常生效。
+
 # 1.2.9 (2026-09-02)
 
 - `cachext` 的两个 redis backend（v6 / v9）的 `Init` 从硬编码 `host`/`password`/`db` 三个字段改为 `config.Unmarshal`，现在 `redis.Options` 的全部字段都能通过配置设置，与 `redisext` 一致。常用的是 `<NS>poolsize` / `<NS>pooltimeout`
@@ -6,7 +29,7 @@
 - `<NS>addr` 作为 `<NS>host` 的等价键名（同时配置时 `addr` 优先）；两者都缺失时 `Init` 直接返回错误，而不是让 go-redis 静默 fallback 到 `localhost:6379`
 - cachext 的 backend 初始化错误现在带上 NS 前缀，便于定位是哪个 CacheExt
 
-⚠️ 配置键名**不能带下划线**：`cache_poolsize` 生效，`cache_pool_size` 会被静默忽略（mapstructure 只做大小写折叠，不做下划线归一化）。时间类参数必须带单位，`500ms` 正确，`500` 会被当成 500 纳秒。
+⚠️ 配置键名**不能带下划线**：`cache_poolsize` 生效，`cache_pool_size` 会被静默忽略（mapstructure 只做大小写折叠，不做下划线归一化）。时间类参数必须带单位，`500ms` 正确，`500` 会被当成 500 纳秒。（下划线写法自 1.2.10 起已支持）
 
 # 1.2.8 (2026-07-27)
 

--- a/docs/ext_cache_cn.md
+++ b/docs/ext_cache_cn.md
@@ -23,29 +23,31 @@ cache_db: 0
 从 v1.2.9 起，`cache_` 段支持 [`redis.Options`](https://pkg.go.dev/github.com/go-redis/redis#Options) 的全部字段，键名是「字段名去掉大小写」，前面加 NS 前缀：
 
 ```yaml
-cache_poolsize: 20 # PoolSize
-cache_pooltimeout: 500ms # PoolTimeout
+cache_poolsize: 100 # PoolSize
+cache_pooltimeout: 100ms # PoolTimeout
 cache_minidleconns: 2 # MinIdleConns
-cache_readtimeout: 3s # ReadTimeout
+cache_readtimeout: 200ms # ReadTimeout
 ```
+
+上面只是键名写法的示意。`poolsize` / `pooltimeout` / `readtimeout` 以及空闲回收这四项 gobay 已有默认值（见下），**通常不需要写进 config.yaml**；只有需要偏离默认值时才显式配置。
 
 **两个容易静默踩错的地方：**
 
-- **键名不能带下划线。** `cache_poolsize` 生效，`cache_pool_size` 会被静默忽略，既不生效也不报错。配置解析走的是 mapstructure 的大小写不敏感匹配，它不会把下划线归一化掉。
+- **键名两种写法都支持。** `cache_poolsize` 与 `cache_pool_size` 等价。配置解析走 mapstructure 的大小写不敏感匹配，它本身不会把下划线归一化掉（1.2.10 之前 `cache_pool_size` 会被静默忽略），现在由 gobay 在 `Unmarshal` 前补齐。两种写法同时出现时以**不带下划线的**为准。
 - **时间类参数必须带单位。** `500ms` / `3s` 正确；写成 `500` 会被解析成 500 **纳秒**。
 
 `cache_host` 是历史键名，等价于 `cache_addr`，两者都支持（同时配置时 `cache_addr` 优先）。两个都没配会直接启动失败，而不是静默连到 `localhost:6379`。
 
 ### PoolSize 的默认值
 
-**gobay 从 v1.2.9 起把 `PoolSize` 默认为 20**，而不是 go-redis 自己的 `10 × NumCPU`。
+**gobay 从 v1.2.10 起把 `PoolSize` 默认为 100**，而不是 go-redis 自己的 `10 × NumCPU`。
 
 原因是 `NumCPU()` 读的是宿主机核数而不是容器的 CPU limit，在多核节点上跑的容器会拿到一个远超实际需要的池上限。这个上限平时看不出来，一旦 redis 变慢就会变成放大器：请求变慢 → 连接被占住 → 池继续扩容 → redis 压力更大。设一个保守的上限，等于把压力挡在服务侧而不是转身建更多连接去压垮 redis。
 
 **v9 backend 会自动让路。** 它用的是 `10 × GOMAXPROCS`，而 Go 1.25 起 GOMAXPROCS 默认会取 `min(可用 CPU 数, cgroup 的 quota/period)`。所以 v9 backend 在启动时会比较 `GOMAXPROCS` 和 `NumCPU`：
 
 - **两者不等** → 说明确实有机制（Go 1.25 的 container-aware GOMAXPROCS，或 automaxprocs）已经把它调下来了，此时 go-redis 自己算的 `10 × GOMAXPROCS` 会随容器规格缩放，比固定值更合理，gobay **不再覆盖**它
-- **两者相等** → 说明没生效，用 gobay 的默认值 20 兜底
+- **两者相等** → 说明没生效，用 gobay 的默认值 100 兜底
 
 判断的是运行结果而不是 `runtime.Version()`：Go 1.25 的这个行为由 `containermaxprocs` GODEBUG 控制，而它的默认值取决于**主模块（也就是你的项目）**go.mod 里的 `go` 指令——gobay 作为依赖库读不到那个值。工具链升到 1.25 但项目 go.mod 还写着 1.24 时，GOMAXPROCS 依然是宿主机核数，这时候放手就等于没修。
 
@@ -55,7 +57,15 @@ cache_readtimeout: 3s # ReadTimeout
 
 需要更大的池就显式配置 `cache_poolsize: <n>`。**要退回 go-redis 的原默认值，配 `cache_poolsize: 0`**，不需要回滚 gobay 版本。没有显式配置时，启动日志里会打印一行说明实际生效的值和来源。
 
-`PoolTimeout` 保持 go-redis 的默认值（`ReadTimeout + 1s` = 4s），gobay 不替业务决定。这个值决定的是「等不到连接时多久放弃」，属于失败语义而不是资源上限——4 秒往往比上游的超时还长，等于把请求堆积留在自己进程里，建议按自己的 SLO 显式配置成 `300ms`–`500ms`。
+除 `PoolSize` 外，从 1.2.10 起还有三项默认值：
+
+| 配置键                                                 | 默认值  | 说明                                                                    |
+| ------------------------------------------------------ | ------- | ----------------------------------------------------------------------- |
+| `<NS>readtimeout`                                      | `200ms` | 单次读操作的超时。go-redis 原默认 3 秒，长于典型在线链路的上游预算      |
+| `<NS>pooltimeout`                                      | `100ms` | 池满时等待可用连接的超时。取 ReadTimeout 的一半，排队不应比执行更久     |
+| `<NS>idletimeout`（v6）<br>`<NS>connmaxidletime`（v9） | `2m`    | 空闲连接的回收时间。v9 原默认 30 分钟，会让连接池在流量回落后迟迟不收缩 |
+
+两个大版本的 backend 取值一致，只有空闲回收的配置键名不同（go-redis 在 v9 里重命名了这个字段）。
 
 ## 设置加载时用的 extension
 

--- a/docs/ext_redis_cn.md
+++ b/docs/ext_redis_cn.md
@@ -7,10 +7,14 @@
 打开 config.yaml 文件，这几个配置
 
 ```yaml
-  redis_host: 'redis:6379'
+  redis_addr: 'redis:6379'
   redis_password: ''
   redis_db: 0
 ```
+
+⚠️ **地址键必须写 `<NS>addr`，不能写 `<NS>host`。** 本扩展把配置直接 `Unmarshal` 进 [`redis.Options`](https://pkg.go.dev/github.com/go-redis/redis#Options)，而该结构体只有 `Addr` 字段、没有 `Host`；mapstructure 找不到对应字段会静默跳过，`Addr` 保持为空，go-redis 随后 fallback 到 `localhost:6379` —— 不报错，连接目标却是错的。
+
+> 注意与 `cachext` 的区别：**`cache_host` 是生效的**。cachext 的 redis backend 里有一段兼容代码，`Addr` 为空时会回落到读 `<NS>host`（历史配置键）。redisext 没有这段兼容，所以只认 `addr`。看到 `cache_host` 不要跟着改。
 
 ## 加载 redis 用的 extension
 
@@ -70,3 +74,22 @@ func InitExts(app *gobay.Application) {
   // 删除 redis 数据
   redisClient.Del(cacheKeys...).Result()
 ```
+
+## 连接池与超时默认值
+
+从 1.2.10 起，`redisext` 在 `Init` 时会注入以下默认值，业务项目无需配置：
+
+| 配置键                                                 | 默认值  | go-redis 原默认值                            |
+| ------------------------------------------------------ | ------- | -------------------------------------------- |
+| `<NS>poolsize`                                         | `100`   | `10 × NumCPU`（v6）/ `10 × GOMAXPROCS`（v9） |
+| `<NS>readtimeout`                                      | `200ms` | `3s`                                         |
+| `<NS>pooltimeout`                                      | `100ms` | ReadTimeout + 1s                             |
+| `<NS>idletimeout`（v6）<br>`<NS>connmaxidletime`（v9） | `2m`    | `5m`（v6）/ `30m`（v9）                      |
+
+`NumCPU()` 读的是宿主机核数而非容器的 CPU limit，多核节点上的容器会拿到远超实际需要的池上限；这个上限会在 redis 变慢时变成放大器（请求堆积 → 建更多连接 → redis 更慢）。三项超时的作用是限制单个连接被占用的时长——按 Little's Law，连接数需求等于请求速率乘以单请求耗时，压缩耗时比限制连接数更早生效。
+
+需要放宽的服务显式配置对应键即可覆盖，`<NS>poolsize: 0` 回到 go-redis 自己的默认值。
+
+⚠️ 键名两种写法都支持（`redis_poolsize` 与 `redis_pool_size` 等价，并存时以前者为准）。时间参数必须带单位。
+
+⚠️ 地址键用 `<NS>addr`，`<NS>host` 不生效，原因见本文开头的配置说明。

--- a/extensions/cachext/backend/redis/redis.go
+++ b/extensions/cachext/backend/redis/redis.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/viper"
 	"go.elastic.co/apm/module/apmgoredis"
 
+	"github.com/shanbay/gobay"
 	"github.com/shanbay/gobay/extensions/cachext"
 	"github.com/shanbay/gobay/observability"
 )
@@ -18,10 +19,36 @@ import (
 // go-redis 默认的 PoolSize 是 10*runtime.NumCPU()。NumCPU 读的是宿主机核数，
 // 不感知容器的 CPU limit，所以在多核节点上跑的容器会拿到一个远超实际需要的池上限。
 // 这个上限平时看不出来，一旦 redis 变慢就会变成放大器：请求堆积 -> 建更多连接 ->
-// redis 更慢。收敛到一个保守的固定值，把压力挡在服务侧。
+// redis 更慢。收敛到一个固定值，把压力挡在服务侧。
 // 注：runtime.NumCPU() 不受 GOMAXPROCS 影响，Go 1.25 的 container-aware GOMAXPROCS
 // 也不会改变它，所以 v6 这边只能靠显式默认值。
-const defaultPoolSize = 20
+//
+// 取值来自实测：单池瞬时连接数峰值不足 100，取整到 100 可覆盖而不触顶。注意不能用
+// 平均值推导——「实例总连接 ÷ pod 数 ÷ 池数」会同时抹平 pod 间负载不均和瞬时并发，
+// 算出来比真实峰值小一个数量级，据此设的上限会误伤正常流量。
+const defaultPoolSize = 100
+
+// go-redis v6 的连接读写和排队都不接受 context：pool.Conn 结构体里没有 ctx 字段，
+// WithReader 只认 ReadTimeout；waitTurn() 连参数都没有，只认 PoolTimeout。也就是说
+// 上游 ctx 到期之后，这次调用占用的连接仍会等满 ReadTimeout 才归还，还在排队的再叠加
+// 一个 PoolTimeout —— 一个已经被放弃的请求最坏能占住连接 7 秒（3s + 4s 的默认值）。
+// redis 一变慢，这就是连接池只涨不落的直接原因。
+//
+// 按 Little's Law，连接数需求等于请求速率乘以单请求耗时，所以压缩耗时比限制连接数
+// 更接近问题本源：PoolSize 只在池已打满后才生效，那时膨胀已经发生。
+//
+// 取值：正常 KV 操作在亚毫秒量级，200ms 仍留三个数量级的余量，同时不长于典型在线
+// 链路的上游预算；PoolTimeout 取其一半，排队不应比执行更久，最坏单次操作 300ms。
+// 有更严预算的服务在 <NS>readtimeout / <NS>pooltimeout 里自行收紧。
+const (
+	defaultReadTimeout = 200 * time.Millisecond
+	defaultPoolTimeout = 100 * time.Millisecond
+)
+
+// 空闲连接回收。v6 的默认值是 5 分钟，本身不算长，收敛到 2 分钟是为了与 v9 backend
+// 保持一致——v9 对应的 ConnMaxIdleTime 默认长达 30 分钟，一次瞬时并发建出来的连接会
+// 被留到半小时后才回收，池子只涨不落。
+const defaultIdleTimeout = 2 * time.Minute
 
 func init() {
 	if err := cachext.RegisterBackend("redis", func() cachext.CacheBackend { return &redisBackend{} }); err != nil {
@@ -41,9 +68,15 @@ func (b *redisBackend) withContext(ctx context.Context) *redis.Client {
 }
 
 func (b *redisBackend) Init(config *viper.Viper) error {
+	// 先补齐下划线写法（<NS>pool_size），否则它会被 mapstructure 静默忽略。
+	// 必须在 IsSet / SetDefault 之前，否则感知不到用户配的是哪种写法。
+	gobay.NormalizeUnderscoreKeys(config)
 	// IsSet 必须在 SetDefault 之前取，否则恒为 true，日志就分不清是用户配的还是这里兜的
 	poolSizeConfigured := config.IsSet("poolsize")
 	config.SetDefault("poolsize", defaultPoolSize)
+	config.SetDefault("readtimeout", defaultReadTimeout)
+	config.SetDefault("pooltimeout", defaultPoolTimeout)
+	config.SetDefault("idletimeout", defaultIdleTimeout)
 
 	opt := redis.Options{}
 	if err := config.Unmarshal(&opt); err != nil {

--- a/extensions/cachext/backend/redis/redis_test.go
+++ b/extensions/cachext/backend/redis/redis_test.go
@@ -75,6 +75,14 @@ func TestInit_MissingAddr(t *testing.T) {
 }
 
 func TestInit_DefaultPoolSize(t *testing.T) {
+	// go-redis v6 的 PoolSize 默认值是 10*runtime.NumCPU()，在 10 核机器上恰好等于
+	// gobay 要设的 100，此时下面的 PoolSize 断言无法区分这个值是谁设的。NumCPU 不像
+	// GOMAXPROCS 那样能在进程内改写，所以只能把这个退化显式报出来——CI runner 的核数
+	// 不是 10，断言在那里是有效的。
+	if 10*runtime.NumCPU() == 100 {
+		t.Logf("注意：本机 NumCPU=%d，go-redis 默认 PoolSize 恰好也是 100，"+
+			"本用例的 PoolSize 断言在此机器上不具区分度", runtime.NumCPU())
+	}
 	b := &redisBackend{}
 	if err := b.Init(cacheConfig(map[string]interface{}{
 		"host": "127.0.0.1:6379",
@@ -138,18 +146,43 @@ func TestInit_PoolTimeout(t *testing.T) {
 
 // mapstructure 只做大小写折叠、不做下划线归一化，所以 pool_size 匹配不上 PoolSize，
 // 会被静默忽略。这条测试把这个行为钉住，免得有人以为支持 snake_case 而写出静默失效的配置。
-func TestInit_SnakeCaseIgnored(t *testing.T) {
+// 带下划线的写法也要生效。mapstructure 只做大小写折叠、不做下划线归一化，
+// 历史上 pool_size 会被静默忽略；现在由 gobay.NormalizeUnderscoreKeys 补齐。
+func TestInit_SnakeCaseAccepted(t *testing.T) {
 	b := &redisBackend{}
 	if err := b.Init(cacheConfig(map[string]interface{}{
-		"host":      "127.0.0.1:6379",
-		"pool_size": 50,
+		"host":         "127.0.0.1:6379",
+		"pool_size":    50,
+		"read_timeout": "150ms",
 	})); err != nil {
 		t.Fatalf("Init failed: %v", err)
 	}
 	defer b.Close()
 
-	if got := b.client.Options().PoolSize; got != defaultPoolSize {
-		t.Errorf("PoolSize = %d, want %d — pool_size (snake_case) must not take effect", got, defaultPoolSize)
+	o := b.client.Options()
+	if o.PoolSize != 50 {
+		t.Errorf("PoolSize = %d, want 50 — pool_size 应当生效", o.PoolSize)
+	}
+	if o.ReadTimeout != 150*time.Millisecond {
+		t.Errorf("ReadTimeout = %v, want 150ms — read_timeout 应当生效", o.ReadTimeout)
+	}
+}
+
+// 两种写法并存时以不带下划线的为准。交给 mapstructure 自行处理的话，两个键都会
+// 匹配同一个字段，最终哪个生效取决于 map 迭代顺序——实测过，是不确定的。
+func TestInit_FlatKeyWinsOverSnakeCase(t *testing.T) {
+	b := &redisBackend{}
+	if err := b.Init(cacheConfig(map[string]interface{}{
+		"host":      "127.0.0.1:6379",
+		"poolsize":  50,
+		"pool_size": 77,
+	})); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	defer b.Close()
+
+	if got := b.client.Options().PoolSize; got != 50 {
+		t.Errorf("PoolSize = %d, want 50 — 并存时应以 poolsize 为准，结果必须确定", got)
 	}
 }
 
@@ -181,5 +214,69 @@ func TestInit_EndToEndFromConfigFile(t *testing.T) {
 	}
 	if opt.PoolTimeout != 9*time.Second {
 		t.Errorf("PoolTimeout = %v, want 9s (from cache_pooltimeout)", opt.PoolTimeout)
+	}
+}
+
+// 取值是决策结果而非实现细节，显式钉住，改动时必须连带改测试
+func TestDefaults_Values(t *testing.T) {
+	if defaultPoolSize != 100 {
+		t.Errorf("defaultPoolSize = %d, want 100", defaultPoolSize)
+	}
+	if defaultReadTimeout != 200*time.Millisecond {
+		t.Errorf("defaultReadTimeout = %v, want 200ms", defaultReadTimeout)
+	}
+	if defaultPoolTimeout != 100*time.Millisecond {
+		t.Errorf("defaultPoolTimeout = %v, want 100ms", defaultPoolTimeout)
+	}
+	if defaultIdleTimeout != 2*time.Minute {
+		t.Errorf("defaultIdleTimeout = %v, want 2m", defaultIdleTimeout)
+	}
+}
+
+// v6 的连接读写和排队都不接受 context，上游超时管不到 redis 调用，
+// 这三个默认值是唯一的闸
+func TestInit_DefaultTimeouts(t *testing.T) {
+	b := &redisBackend{}
+	if err := b.Init(cacheConfig(map[string]interface{}{
+		"host": "127.0.0.1:6379",
+	})); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	defer b.Close()
+
+	o := b.client.Options()
+	if o.ReadTimeout != defaultReadTimeout {
+		t.Errorf("ReadTimeout = %v, want %v", o.ReadTimeout, defaultReadTimeout)
+	}
+	if o.PoolTimeout != defaultPoolTimeout {
+		t.Errorf("PoolTimeout = %v, want %v", o.PoolTimeout, defaultPoolTimeout)
+	}
+	if o.IdleTimeout != defaultIdleTimeout {
+		t.Errorf("IdleTimeout = %v, want %v", o.IdleTimeout, defaultIdleTimeout)
+	}
+}
+
+// 有更严预算的服务可以自己收紧，显式配置优先于默认值
+func TestInit_ExplicitTimeoutsWin(t *testing.T) {
+	b := &redisBackend{}
+	if err := b.Init(cacheConfig(map[string]interface{}{
+		"host":        "127.0.0.1:6379",
+		"readtimeout": "120ms",
+		"pooltimeout": "60ms",
+		"idletimeout": "30s",
+	})); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	defer b.Close()
+
+	o := b.client.Options()
+	if o.ReadTimeout != 120*time.Millisecond {
+		t.Errorf("ReadTimeout = %v, want 120ms", o.ReadTimeout)
+	}
+	if o.PoolTimeout != 60*time.Millisecond {
+		t.Errorf("PoolTimeout = %v, want 60ms", o.PoolTimeout)
+	}
+	if o.IdleTimeout != 30*time.Second {
+		t.Errorf("IdleTimeout = %v, want 30s", o.IdleTimeout)
 	}
 }

--- a/extensions/cachext/backend/redis/v9/redis.go
+++ b/extensions/cachext/backend/redis/v9/redis.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/viper"
 	"go.opentelemetry.io/otel"
 
+	"github.com/shanbay/gobay"
 	"github.com/shanbay/gobay/extensions/cachext"
 	"github.com/shanbay/gobay/observability"
 )
@@ -19,7 +20,27 @@ import (
 // go-redis 默认的 PoolSize 是 10*runtime.GOMAXPROCS(0)。当 GOMAXPROCS 仍等于宿主机
 // 核数时，多核节点上的容器会拿到一个远超实际需要的池上限。这个上限平时看不出来，
 // 一旦 redis 变慢就会变成放大器：请求堆积 -> 建更多连接 -> redis 更慢。
-const defaultPoolSize = 20
+//
+// 取值来自实测：单池瞬时连接数峰值不足 100，取整到 100 可覆盖而不触顶。注意不能用
+// 平均值推导——「实例总连接 ÷ pod 数 ÷ 池数」会同时抹平 pod 间负载不均和瞬时并发，
+// 算出来比真实峰值小一个数量级，据此设的上限会误伤正常流量。
+const defaultPoolSize = 100
+
+// v9 的 pool.Conn.deadline 取 min(ctx.Deadline(), now+ReadTimeout)，waitTurn 也接受
+// ctx，所以上游预算能自动传导。但两者是互补关系而非替代：ReadTimeout 是静态上界，
+// 兜住没有 deadline 的调用（离线任务、cronjob），不设的话它们会落在 3 秒的默认值上；
+// ctx 是动态剩余预算，上游已消耗大部分时间时能比静态上界更早放弃。
+//
+// 取值与 v6 backend 保持一致：正常 KV 操作在亚毫秒量级，200ms 留三个数量级余量；
+// PoolTimeout 取其一半，最坏单次操作 300ms。
+const (
+	defaultReadTimeout = 200 * time.Millisecond
+	defaultPoolTimeout = 100 * time.Millisecond
+)
+
+// go-redis v9 的 ConnMaxIdleTime 默认是 30 分钟，一次瞬时并发建出来的连接会被留到
+// 半小时后才回收，池子只涨不落。收敛到 2 分钟，让峰值过去后连接数能跟着回落。
+const defaultConnMaxIdleTime = 2 * time.Minute
 
 // cpuLimitAware 报告 GOMAXPROCS 是否已经反映了容器的 CPU 限额。
 //
@@ -49,12 +70,19 @@ type redisBackend struct {
 }
 
 func (b *redisBackend) Init(config *viper.Viper) error {
+	// 先补齐下划线写法（<NS>pool_size），否则它会被 mapstructure 静默忽略。
+	// 必须在 IsSet / SetDefault 之前，否则感知不到用户配的是哪种写法。
+	gobay.NormalizeUnderscoreKeys(config)
 	// IsSet 必须在 SetDefault 之前取，否则恒为 true，日志就分不清是用户配的还是这里兜的
 	poolSizeConfigured := config.IsSet("poolsize")
 	trustGoRedis := cpuLimitAware()
 	if !trustGoRedis {
 		config.SetDefault("poolsize", defaultPoolSize)
 	}
+	// 超时与 CPU 核数无关，无论 GOMAXPROCS 是否已感知容器限额都要设
+	config.SetDefault("readtimeout", defaultReadTimeout)
+	config.SetDefault("pooltimeout", defaultPoolTimeout)
+	config.SetDefault("connmaxidletime", defaultConnMaxIdleTime)
 
 	opt := redis.Options{}
 	if err := config.Unmarshal(&opt); err != nil {

--- a/extensions/cachext/backend/redis/v9/redis_test.go
+++ b/extensions/cachext/backend/redis/v9/redis_test.go
@@ -138,18 +138,43 @@ func TestInit_PoolTimeout(t *testing.T) {
 
 // mapstructure 只做大小写折叠、不做下划线归一化，所以 pool_size 匹配不上 PoolSize，
 // 会被静默忽略。这条测试把这个行为钉住，免得有人以为支持 snake_case 而写出静默失效的配置。
-func TestInit_SnakeCaseIgnored(t *testing.T) {
+// 带下划线的写法也要生效。mapstructure 只做大小写折叠、不做下划线归一化，
+// 历史上 pool_size 会被静默忽略；现在由 gobay.NormalizeUnderscoreKeys 补齐。
+func TestInit_SnakeCaseAccepted(t *testing.T) {
 	b := &redisBackend{}
 	if err := b.Init(cacheConfig(map[string]interface{}{
-		"host":      "127.0.0.1:6379",
-		"pool_size": 50,
+		"host":         "127.0.0.1:6379",
+		"pool_size":    50,
+		"read_timeout": "150ms",
 	})); err != nil {
 		t.Fatalf("Init failed: %v", err)
 	}
 	defer b.Close()
 
-	if got := b.client.Options().PoolSize; got != defaultPoolSize {
-		t.Errorf("PoolSize = %d, want %d — pool_size (snake_case) must not take effect", got, defaultPoolSize)
+	o := b.client.Options()
+	if o.PoolSize != 50 {
+		t.Errorf("PoolSize = %d, want 50 — pool_size 应当生效", o.PoolSize)
+	}
+	if o.ReadTimeout != 150*time.Millisecond {
+		t.Errorf("ReadTimeout = %v, want 150ms — read_timeout 应当生效", o.ReadTimeout)
+	}
+}
+
+// 两种写法并存时以不带下划线的为准。交给 mapstructure 自行处理的话，两个键都会
+// 匹配同一个字段，最终哪个生效取决于 map 迭代顺序——实测过，是不确定的。
+func TestInit_FlatKeyWinsOverSnakeCase(t *testing.T) {
+	b := &redisBackend{}
+	if err := b.Init(cacheConfig(map[string]interface{}{
+		"host":      "127.0.0.1:6379",
+		"poolsize":  50,
+		"pool_size": 77,
+	})); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	defer b.Close()
+
+	if got := b.client.Options().PoolSize; got != 50 {
+		t.Errorf("PoolSize = %d, want 50 — 并存时应以 poolsize 为准，结果必须确定", got)
 	}
 }
 
@@ -227,5 +252,95 @@ func TestInit_ExplicitPoolSizeWinsWhenCPULimitAware(t *testing.T) {
 
 	if got := b.client.Options().PoolSize; got != 33 {
 		t.Errorf("PoolSize = %d, want 33", got)
+	}
+}
+
+// 取值是决策结果而非实现细节，显式钉住，改动时必须连带改测试
+func TestDefaults_Values(t *testing.T) {
+	if defaultPoolSize != 100 {
+		t.Errorf("defaultPoolSize = %d, want 100", defaultPoolSize)
+	}
+	if defaultReadTimeout != 200*time.Millisecond {
+		t.Errorf("defaultReadTimeout = %v, want 200ms", defaultReadTimeout)
+	}
+	if defaultPoolTimeout != 100*time.Millisecond {
+		t.Errorf("defaultPoolTimeout = %v, want 100ms", defaultPoolTimeout)
+	}
+	if defaultConnMaxIdleTime != 2*time.Minute {
+		t.Errorf("defaultConnMaxIdleTime = %v, want 2m", defaultConnMaxIdleTime)
+	}
+}
+
+// v9 的 deadline 取 min(ctx.Deadline(), now+ReadTimeout)：ReadTimeout 是静态上界，
+// 兜住没有 deadline 的离线调用；ctx 是动态剩余预算。两者互补，所以 v9 同样要设。
+func TestInit_DefaultTimeouts(t *testing.T) {
+	b := &redisBackend{}
+	if err := b.Init(cacheConfig(map[string]interface{}{
+		"host": "127.0.0.1:6379",
+	})); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	defer b.Close()
+
+	o := b.client.Options()
+	if o.ReadTimeout != defaultReadTimeout {
+		t.Errorf("ReadTimeout = %v, want %v", o.ReadTimeout, defaultReadTimeout)
+	}
+	if o.PoolTimeout != defaultPoolTimeout {
+		t.Errorf("PoolTimeout = %v, want %v", o.PoolTimeout, defaultPoolTimeout)
+	}
+	if o.ConnMaxIdleTime != defaultConnMaxIdleTime {
+		t.Errorf("ConnMaxIdleTime = %v, want %v", o.ConnMaxIdleTime, defaultConnMaxIdleTime)
+	}
+}
+
+func TestInit_ExplicitTimeoutsWin(t *testing.T) {
+	b := &redisBackend{}
+	if err := b.Init(cacheConfig(map[string]interface{}{
+		"host":            "127.0.0.1:6379",
+		"readtimeout":     "120ms",
+		"pooltimeout":     "60ms",
+		"connmaxidletime": "30s",
+	})); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	defer b.Close()
+
+	o := b.client.Options()
+	if o.ReadTimeout != 120*time.Millisecond {
+		t.Errorf("ReadTimeout = %v, want 120ms", o.ReadTimeout)
+	}
+	if o.PoolTimeout != 60*time.Millisecond {
+		t.Errorf("PoolTimeout = %v, want 60ms", o.PoolTimeout)
+	}
+	if o.ConnMaxIdleTime != 30*time.Second {
+		t.Errorf("ConnMaxIdleTime = %v, want 30s", o.ConnMaxIdleTime)
+	}
+}
+
+// 超时默认值与 CPU 核数无关，即使 GOMAXPROCS 已感知容器限额（PoolSize 交还给
+// go-redis 自己算）也必须照常生效
+func TestInit_TimeoutsApplyWhenCPULimitAware(t *testing.T) {
+	if runtime.NumCPU() < 2 {
+		t.Skip("需要至少 2 个 CPU")
+	}
+	prev := runtime.GOMAXPROCS(1)
+	defer runtime.GOMAXPROCS(prev)
+
+	b := &redisBackend{}
+	if err := b.Init(cacheConfig(map[string]interface{}{
+		"host": "127.0.0.1:6379",
+	})); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	defer b.Close()
+
+	o := b.client.Options()
+	if o.PoolSize != 10 {
+		t.Errorf("PoolSize = %d, want 10 (10*GOMAXPROCS，不该被 gobay 默认值覆盖)", o.PoolSize)
+	}
+	if o.ReadTimeout != defaultReadTimeout {
+		t.Errorf("ReadTimeout = %v, want %v（超时与 CPU 核数无关，必须照常生效）",
+			o.ReadTimeout, defaultReadTimeout)
 	}
 }

--- a/extensions/redisext/defaults_test.go
+++ b/extensions/redisext/defaults_test.go
@@ -1,0 +1,114 @@
+package redisext_test
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/shanbay/gobay"
+	"github.com/shanbay/gobay/extensions/redisext"
+)
+
+// 不配任何连接池参数时，应当拿到 gobay 的默认值而不是 go-redis 的
+func TestInit_Defaults(t *testing.T) {
+	// go-redis v6 的 PoolSize 默认值是 10*runtime.NumCPU()，在 10 核机器上恰好等于
+	// gobay 要设的 100，此时下面的 PoolSize 断言无法区分这个值是谁设的。NumCPU 不像
+	// GOMAXPROCS 那样能在进程内改写，所以只能把这个退化显式报出来——CI runner 的核数
+	// 不是 10，断言在那里是有效的。
+	if 10*runtime.NumCPU() == 100 {
+		t.Logf("注意：本机 NumCPU=%d，go-redis 默认 PoolSize 恰好也是 100，"+
+			"本用例的 PoolSize 断言在此机器上不具区分度", runtime.NumCPU())
+	}
+	ext := &redisext.RedisExt{NS: "redis_"}
+	exts := map[gobay.Key]gobay.Extension{"redis": ext}
+	if _, err := gobay.CreateApp("../../testdata/", "redispool", exts); err != nil {
+		t.Fatalf("CreateApp failed: %v", err)
+	}
+	defer ext.Close()
+
+	o := ext.Client(context.Background()).Options()
+	if o.PoolSize != 100 {
+		t.Errorf("PoolSize = %d, want 100", o.PoolSize)
+	}
+	if o.ReadTimeout != 200*time.Millisecond {
+		t.Errorf("ReadTimeout = %v, want 200ms", o.ReadTimeout)
+	}
+	if o.PoolTimeout != 100*time.Millisecond {
+		t.Errorf("PoolTimeout = %v, want 100ms", o.PoolTimeout)
+	}
+	if o.IdleTimeout != 2*time.Minute {
+		t.Errorf("IdleTimeout = %v, want 2m", o.IdleTimeout)
+	}
+}
+
+// 显式配置优先于默认值
+func TestInit_ExplicitWins(t *testing.T) {
+	ext := &redisext.RedisExt{NS: "redisexplicit_"}
+	exts := map[gobay.Key]gobay.Extension{"redis": ext}
+	if _, err := gobay.CreateApp("../../testdata/", "redispool", exts); err != nil {
+		t.Fatalf("CreateApp failed: %v", err)
+	}
+	defer ext.Close()
+
+	o := ext.Client(context.Background()).Options()
+	if o.PoolSize != 33 {
+		t.Errorf("PoolSize = %d, want 33", o.PoolSize)
+	}
+	if o.ReadTimeout != 120*time.Millisecond {
+		t.Errorf("ReadTimeout = %v, want 120ms", o.ReadTimeout)
+	}
+	if o.PoolTimeout != 60*time.Millisecond {
+		t.Errorf("PoolTimeout = %v, want 60ms", o.PoolTimeout)
+	}
+	if o.IdleTimeout != 30*time.Second {
+		t.Errorf("IdleTimeout = %v, want 30s", o.IdleTimeout)
+	}
+}
+
+// 逃生门：显式配 0 让 go-redis 回填自己的默认值，不必回滚版本
+func TestInit_PoolSizeEscapeHatch(t *testing.T) {
+	ext := &redisext.RedisExt{NS: "redisescape_"}
+	exts := map[gobay.Key]gobay.Extension{"redis": ext}
+	if _, err := gobay.CreateApp("../../testdata/", "redispool", exts); err != nil {
+		t.Fatalf("CreateApp failed: %v", err)
+	}
+	defer ext.Close()
+
+	want := 10 * runtime.NumCPU()
+	if o := ext.Client(context.Background()).Options(); o.PoolSize != want {
+		t.Errorf("PoolSize = %d, want %d (go-redis 默认值)", o.PoolSize, want)
+	}
+}
+
+// 带下划线的写法也要生效（历史上会被 mapstructure 静默忽略）
+func TestInit_SnakeCaseAccepted(t *testing.T) {
+	ext := &redisext.RedisExt{NS: "redisunderscore_"}
+	exts := map[gobay.Key]gobay.Extension{"redis": ext}
+	if _, err := gobay.CreateApp("../../testdata/", "redispool", exts); err != nil {
+		t.Fatalf("CreateApp failed: %v", err)
+	}
+	defer ext.Close()
+
+	o := ext.Client(context.Background()).Options()
+	if o.PoolSize != 50 {
+		t.Errorf("PoolSize = %d, want 50 — pool_size 应当生效", o.PoolSize)
+	}
+	if o.ReadTimeout != 150*time.Millisecond {
+		t.Errorf("ReadTimeout = %v, want 150ms — read_timeout 应当生效", o.ReadTimeout)
+	}
+}
+
+// 两种写法并存时以不带下划线的为准，结果必须确定
+func TestInit_FlatKeyWinsOverSnakeCase(t *testing.T) {
+	ext := &redisext.RedisExt{NS: "redisboth_"}
+	exts := map[gobay.Key]gobay.Extension{"redis": ext}
+	if _, err := gobay.CreateApp("../../testdata/", "redispool", exts); err != nil {
+		t.Fatalf("CreateApp failed: %v", err)
+	}
+	defer ext.Close()
+
+	if got := ext.Client(context.Background()).Options().PoolSize; got != 50 {
+		t.Errorf("PoolSize = %d, want 50 — 并存时应以 poolsize 为准", got)
+	}
+}

--- a/extensions/redisext/ext.go
+++ b/extensions/redisext/ext.go
@@ -26,12 +26,35 @@ type RedisExt struct {
 
 var _ gobay.Extension = (*RedisExt)(nil)
 
+// go-redis 默认的 PoolSize 是 10*runtime.NumCPU()，NumCPU 读的是宿主机核数、不感知
+// 容器的 CPU limit，多核节点上的容器会拿到远超实际需要的池上限；redis 一变慢就会变成
+// 放大器：请求堆积 -> 建更多连接 -> redis 更慢。
+//
+// 三个超时同样重要：go-redis v6 的连接读写和排队都不接受 context，上游 ctx 到期之后
+// 连接仍会等满 ReadTimeout 才归还，排队中的再叠加 PoolTimeout。按 Little's Law，连接
+// 数需求等于请求速率乘以单请求耗时，压缩耗时比限制连接数更接近问题本源。
+//
+// 取值与 cachext 的 redis backend 保持一致。需要放宽的服务显式配置对应键覆盖，
+// <NS>poolsize 配 0 则回到 go-redis 自己的默认值。
+const (
+	defaultPoolSize    = 100
+	defaultReadTimeout = 200 * time.Millisecond
+	defaultPoolTimeout = 100 * time.Millisecond
+	defaultIdleTimeout = 2 * time.Minute
+)
+
 func (c *RedisExt) Init(app *gobay.Application) error {
 	if c.NS == "" {
 		return errors.New("lack of NS")
 	}
 	c.app = app
 	config := gobay.GetConfigByPrefix(app.Config(), c.NS, true)
+	// 先补齐下划线写法（<NS>pool_size），否则会被 mapstructure 静默忽略
+	gobay.NormalizeUnderscoreKeys(config)
+	config.SetDefault("poolsize", defaultPoolSize)
+	config.SetDefault("readtimeout", defaultReadTimeout)
+	config.SetDefault("pooltimeout", defaultPoolTimeout)
+	config.SetDefault("idletimeout", defaultIdleTimeout)
 	opt := redis.Options{}
 	if err := config.Unmarshal(&opt); err != nil {
 		return err

--- a/extensions/redisext/v9/defaults_test.go
+++ b/extensions/redisext/v9/defaults_test.go
@@ -1,0 +1,102 @@
+package redisv9ext_test
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/shanbay/gobay"
+	redisv9ext "github.com/shanbay/gobay/extensions/redisext/v9"
+)
+
+// 不配任何连接池参数时，应当拿到 gobay 的默认值而不是 go-redis 的
+func TestInit_Defaults(t *testing.T) {
+	// go-redis v9 的 PoolSize 默认值是 10*GOMAXPROCS(0)。在 10 核机器上它恰好等于
+	// gobay 要设的 100，断言就分不出这个值是谁设的了（v6 那边因为用的是 NumCPU，
+	// 无法在进程内规避，只能靠 CI 的核数不同）。这里把 GOMAXPROCS 压到 1，让
+	// go-redis 的默认值变成 10，与 100 拉开距离，断言在任何机器上都有区分度。
+	// redisext v9 无条件 SetDefault，不像 cachext v9 backend 那样有 cpuLimitAware
+	// 分支，所以压低 GOMAXPROCS 不会改变它设默认值的行为。
+	if runtime.NumCPU() < 2 {
+		t.Skip("需要至少 2 个 CPU")
+	}
+	prev := runtime.GOMAXPROCS(1)
+	defer runtime.GOMAXPROCS(prev)
+
+	ext := &redisv9ext.RedisExt{NS: "redis_"}
+	exts := map[gobay.Key]gobay.Extension{"redis": ext}
+	if _, err := gobay.CreateApp("../../../testdata/", "redispool", exts); err != nil {
+		t.Fatalf("CreateApp failed: %v", err)
+	}
+	defer ext.Close()
+
+	o := ext.Client().Options()
+	if o.PoolSize != 100 {
+		t.Errorf("PoolSize = %d, want 100", o.PoolSize)
+	}
+	if o.ReadTimeout != 200*time.Millisecond {
+		t.Errorf("ReadTimeout = %v, want 200ms", o.ReadTimeout)
+	}
+	if o.PoolTimeout != 100*time.Millisecond {
+		t.Errorf("PoolTimeout = %v, want 100ms", o.PoolTimeout)
+	}
+	if o.ConnMaxIdleTime != 2*time.Minute {
+		t.Errorf("ConnMaxIdleTime = %v, want 2m", o.ConnMaxIdleTime)
+	}
+}
+
+// 显式配置优先于默认值
+func TestInit_ExplicitWins(t *testing.T) {
+	ext := &redisv9ext.RedisExt{NS: "redisexplicit_"}
+	exts := map[gobay.Key]gobay.Extension{"redis": ext}
+	if _, err := gobay.CreateApp("../../../testdata/", "redispool", exts); err != nil {
+		t.Fatalf("CreateApp failed: %v", err)
+	}
+	defer ext.Close()
+
+	o := ext.Client().Options()
+	if o.PoolSize != 33 {
+		t.Errorf("PoolSize = %d, want 33", o.PoolSize)
+	}
+	if o.ReadTimeout != 120*time.Millisecond {
+		t.Errorf("ReadTimeout = %v, want 120ms", o.ReadTimeout)
+	}
+	if o.PoolTimeout != 60*time.Millisecond {
+		t.Errorf("PoolTimeout = %v, want 60ms", o.PoolTimeout)
+	}
+	if o.ConnMaxIdleTime != 30*time.Second {
+		t.Errorf("ConnMaxIdleTime = %v, want 30s", o.ConnMaxIdleTime)
+	}
+}
+
+// 带下划线的写法也要生效（历史上会被 mapstructure 静默忽略）
+func TestInit_SnakeCaseAccepted(t *testing.T) {
+	ext := &redisv9ext.RedisExt{NS: "redisunderscore_"}
+	exts := map[gobay.Key]gobay.Extension{"redis": ext}
+	if _, err := gobay.CreateApp("../../../testdata/", "redispool", exts); err != nil {
+		t.Fatalf("CreateApp failed: %v", err)
+	}
+	defer ext.Close()
+
+	o := ext.Client().Options()
+	if o.PoolSize != 50 {
+		t.Errorf("PoolSize = %d, want 50 — pool_size 应当生效", o.PoolSize)
+	}
+	if o.ReadTimeout != 150*time.Millisecond {
+		t.Errorf("ReadTimeout = %v, want 150ms — read_timeout 应当生效", o.ReadTimeout)
+	}
+}
+
+// 两种写法并存时以不带下划线的为准，结果必须确定
+func TestInit_FlatKeyWinsOverSnakeCase(t *testing.T) {
+	ext := &redisv9ext.RedisExt{NS: "redisboth_"}
+	exts := map[gobay.Key]gobay.Extension{"redis": ext}
+	if _, err := gobay.CreateApp("../../../testdata/", "redispool", exts); err != nil {
+		t.Fatalf("CreateApp failed: %v", err)
+	}
+	defer ext.Close()
+
+	if got := ext.Client().Options().PoolSize; got != 50 {
+		t.Errorf("PoolSize = %d, want 50 — 并存时应以 poolsize 为准", got)
+	}
+}

--- a/extensions/redisext/v9/ext.go
+++ b/extensions/redisext/v9/ext.go
@@ -26,12 +26,34 @@ type RedisExt struct {
 
 var _ gobay.Extension = (*RedisExt)(nil)
 
+// go-redis 默认的 PoolSize 是 10*runtime.GOMAXPROCS(0)，当 GOMAXPROCS 仍等于宿主机
+// 核数时，多核节点上的容器会拿到远超实际需要的池上限；redis 一变慢就会变成放大器。
+//
+// v9 的 deadline 取 min(ctx.Deadline(), now+ReadTimeout)，与 ReadTimeout 是互补关系：
+// 后者是静态上界，兜住没有 deadline 的调用（离线任务、cronjob），不设的话它们会落在
+// 3 秒的默认值上；ctx 则是动态剩余预算。
+//
+// 取值与 cachext 的 redis backend 保持一致。需要放宽的服务显式配置对应键覆盖，
+// <NS>poolsize 配 0 则回到 go-redis 自己的默认值。
+const (
+	defaultPoolSize        = 100
+	defaultReadTimeout     = 200 * time.Millisecond
+	defaultPoolTimeout     = 100 * time.Millisecond
+	defaultConnMaxIdleTime = 2 * time.Minute
+)
+
 func (c *RedisExt) Init(app *gobay.Application) error {
 	if c.NS == "" {
 		return errors.New("lack of NS")
 	}
 	c.app = app
 	config := gobay.GetConfigByPrefix(app.Config(), c.NS, true)
+	// 先补齐下划线写法（<NS>pool_size），否则会被 mapstructure 静默忽略
+	gobay.NormalizeUnderscoreKeys(config)
+	config.SetDefault("poolsize", defaultPoolSize)
+	config.SetDefault("readtimeout", defaultReadTimeout)
+	config.SetDefault("pooltimeout", defaultPoolTimeout)
+	config.SetDefault("connmaxidletime", defaultConnMaxIdleTime)
 	opt := redis.Options{}
 	if err := config.Unmarshal(&opt); err != nil {
 		return err

--- a/testdata/config.yaml
+++ b/testdata/config.yaml
@@ -113,6 +113,25 @@ cacheredis:
   cache_backend: "redis"
   cache_poolsize: 7
   cache_pooltimeout: "9s"
+# redispool 验证 redisext 的连接池默认值：redis_ 段不配任何池参数走默认值，
+# redisexplicit_ 段显式配置以验证优先级，redisescape_ 段验证 poolsize: 0 逃生门。
+# 注意用 addr 而非 host —— redisext 的 host 键不生效（见文档说明）
+redispool:
+  <<: *defaults
+  redisexplicit_addr: "127.0.0.1:6379"
+  redisexplicit_poolsize: 33
+  redisexplicit_readtimeout: "120ms"
+  redisexplicit_pooltimeout: "60ms"
+  redisexplicit_idletimeout: "30s"
+  redisexplicit_connmaxidletime: "30s"
+  redisescape_addr: "127.0.0.1:6379"
+  redisescape_poolsize: 0
+  redisunderscore_addr: "127.0.0.1:6379"
+  redisunderscore_pool_size: 50
+  redisunderscore_read_timeout: "150ms"
+  redisboth_addr: "127.0.0.1:6379"
+  redisboth_poolsize: 50
+  redisboth_pool_size: 77
 asynctaskmonitored:
   <<: *defaults
   # three_asynctask_ / four_asynctask_ are dedicated NS prefixes (distinct


### PR DESCRIPTION
`cachext` 与 `redisext` 的 v6/v9 四个入口在 `Init` 时注入连接池与超时默认值，**业务项目无需任何配置**。

| 参数 | 默认值 | 配置键（v6 / v9） | go-redis 原默认值 |
|---|---|---|---|
| 连接池上限 | 100 | `<NS>poolsize` | `10 × NumCPU` / `10 × GOMAXPROCS` |
| 读超时 | 200ms | `<NS>readtimeout` | 3s |
| 排队超时 | 100ms | `<NS>pooltimeout` | ReadTimeout + 1s |
| 空闲回收 | 2m | `<NS>idletimeout` / `<NS>connmaxidletime` | 5m / 30m |

另外支持了**下划线键名**：新增 `gobay.NormalizeUnderscoreKeys`，`<NS>pool_size` 与 `<NS>poolsize` 现在等价。此前前者会被 mapstructure 静默忽略（它只做大小写折叠），是个很难排查的坑。两种写法并存时以**不带下划线的**为准——交给 mapstructure 自行处理的话，哪个生效取决于 map 迭代顺序，实测是不确定的。

## 为什么

`NumCPU()` 读的是宿主机核数而非容器的 CPU limit，多核节点上的容器会拿到远超需要的池上限；redis 一变慢就成为放大器：请求堆积 → 建更多连接 → redis 更慢。

三项超时限制的是单连接被占用的时长。按 Little's Law，连接数需求 = 请求速率 × 单请求耗时，压缩耗时比限制连接数更早生效——`PoolSize` 只在池已打满后才起作用。

v6 尤其需要：它的连接读写与排队都不接受 `context`（`pool.Conn` 没有 ctx 字段，`waitTurn()` 无参数），上游超时管不到 redis 调用。v9 取 `min(ctx.Deadline(), now+ReadTimeout)`，静态上界仍需兜住无 deadline 的调用（离线任务、cronjob），否则落在 3 秒上。

## 兼容性

- 显式配置对应键即可覆盖；`<NS>poolsize: 0` 回到 go-redis 默认值，不必回滚版本
- `PoolSize` 由 1.2.9 的 20 提高到 100（20 过于保守，会限制正常流量下的连接需求）
- 下划线支持是放宽而非收紧，原有的无下划线写法行为不变

## 测试

`redisext` 此前只有无断言的 Example 测试，本次补上首批断言。每项默认值与键名归一化都做了变异检查：删掉对应实现后确认转红。v9 那条能抓住「把 `readtimeout` 误挪进 `if !trustGoRedis` 分支」这个典型错误。

⚠️ 已在代码中标注的测试陷阱：v6 的默认 `PoolSize` 是 `10 × NumCPU`，在 **10 核**机器上恰好等于 100，相关断言会失去区分度（`NumCPU` 无法在进程内改写，用例会打印提示）；v9 用 `runtime.GOMAXPROCS(1)` 规避。

## 不在本 PR 范围

- `redisext` 的 `<NS>host` 静默失效（`redis.Options` 只有 `Addr`）。修复会改变现有服务的连接目标，属独立变更；本 PR 只把文档示例改为 `<NS>addr` 并加警告。注意 `cachext` 有兜底，`cache_host` 照常生效。
- `cachext` backend 的 `Get` 丢弃 go-redis error，涉及接口变更与降级策略，需单独评估。

🤖 Generated with [Claude Code](https://claude.com/claude-code)