### PR TITLE
feat(observability): v9 redis 插桩只在有已采样父级时才开 span，不再产出孤儿

### DIFF
--- a/extensions/cachext/backend/redis/v9/otel_test.go
+++ b/extensions/cachext/backend/redis/v9/otel_test.go
@@ -1,0 +1,79 @@
+package redis
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func otelRecorder(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+	t.Setenv("OTEL_ENABLE", "true")
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prev)
+		_ = tp.Shutdown(context.Background())
+	})
+	return exp
+}
+
+func newBackend(t *testing.T) *redisBackend {
+	t.Helper()
+	b := &redisBackend{}
+	if err := b.Init(cacheConfig(map[string]interface{}{"addr": "127.0.0.1:6379"})); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	t.Cleanup(func() { _ = b.Close() })
+	return b
+}
+
+var parentSpanID = trace.SpanID{0x00, 0xf0, 0x67, 0xaa, 0x0b, 0xa9, 0x02, 0xb7}
+
+func sampledParent() context.Context {
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    trace.TraceID{0x4b, 0xf9, 0x2f, 0x35, 0x77, 0xb3, 0x4d, 0xa6, 0xa3, 0xce, 0x92, 0x9d, 0x0e, 0x0e, 0x47, 0x36},
+		SpanID:     parentSpanID,
+		TraceFlags: trace.FlagsSampled,
+		Remote:     true,
+	})
+	return trace.ContextWithRemoteSpanContext(context.Background(), sc)
+}
+
+// CheckHealth 用的就是探针 ctx（无 span）：不能再产出孤儿 ping
+func TestOtel_CheckHealthWithoutParentExportsNoSpan(t *testing.T) {
+	exp := otelRecorder(t)
+	b := newBackend(t)
+	exp.Reset()
+
+	if err := b.CheckHealth(context.Background()); err != nil {
+		t.Fatalf("CheckHealth failed: %v", err)
+	}
+	if spans := exp.GetSpans(); len(spans) != 0 {
+		t.Fatalf("exported %d orphan spans, want 0", len(spans))
+	}
+}
+
+func TestOtel_GetUnderSampledParentExportsChildSpan(t *testing.T) {
+	exp := otelRecorder(t)
+	b := newBackend(t)
+	exp.Reset()
+
+	_, _ = b.Get(sampledParent(), "gobay-otel-child-test")
+
+	spans := exp.GetSpans()
+	if len(spans) == 0 {
+		t.Fatal("exported 0 spans, want the redis get span")
+	}
+	for _, s := range spans {
+		if s.Parent.SpanID() != parentSpanID {
+			t.Errorf("span %q parent = %s, want %s", s.Name, s.Parent.SpanID(), parentSpanID)
+		}
+	}
+}

--- a/extensions/cachext/backend/redis/v9/redis.go
+++ b/extensions/cachext/backend/redis/v9/redis.go
@@ -10,7 +10,6 @@ import (
 	"github.com/redis/go-redis/extra/redisotel/v9"
 	"github.com/redis/go-redis/v9"
 	"github.com/spf13/viper"
-	"go.opentelemetry.io/otel"
 
 	"github.com/shanbay/gobay"
 	"github.com/shanbay/gobay/extensions/cachext"
@@ -112,7 +111,9 @@ func (b *redisBackend) Init(config *viper.Viper) error {
 	redisClient := redis.NewClient(&opt)
 	b.client = redisClient
 	if observability.GetOtelEnable() {
-		tp := otel.GetTracerProvider()
+		// 官方 redisotel 没有 SpanFilter，交给它全局 provider 会把无父级的命令记成孤儿 span，
+		// 换成只在有已采样父级时才开 span 的 provider（与 otelsql / redisotelv6 语义一致）
+		tp := observability.ChildOnlyTracerProvider()
 		if err := redisotel.InstrumentTracing(redisClient, redisotel.WithTracerProvider(tp)); err != nil {
 			return err
 		}

--- a/extensions/redisext/v9/ext.go
+++ b/extensions/redisext/v9/ext.go
@@ -13,7 +13,6 @@ import (
 	"github.com/redis/go-redis/extra/redisotel/v9"
 	"github.com/redis/go-redis/v9"
 	"github.com/shanbay/gobay"
-	"go.opentelemetry.io/otel"
 )
 
 // RedisExt redis扩展，处理client的初始化工作
@@ -61,7 +60,9 @@ func (c *RedisExt) Init(app *gobay.Application) error {
 	c.prefix = config.GetString("prefix")
 	c.redisClient = redis.NewClient(&opt)
 	if observability.GetOtelEnable() {
-		tp := otel.GetTracerProvider()
+		// 官方 redisotel 没有 SpanFilter，交给它全局 provider 会把无父级的命令记成孤儿 span，
+		// 换成只在有已采样父级时才开 span 的 provider（与 otelsql / redisotelv6 语义一致）
+		tp := observability.ChildOnlyTracerProvider()
 		if err := redisotel.InstrumentTracing(c.redisClient, redisotel.WithTracerProvider(tp)); err != nil {
 			return err
 		}

--- a/extensions/redisext/v9/otel_test.go
+++ b/extensions/redisext/v9/otel_test.go
@@ -1,0 +1,101 @@
+package redisv9ext_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shanbay/gobay"
+	redisv9ext "github.com/shanbay/gobay/extensions/redisext/v9"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// 与线上一致的全局 provider：不设 Sampler → ParentBased(AlwaysSample)
+func otelRecorder(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prev)
+		_ = tp.Shutdown(context.Background())
+	})
+	return exp
+}
+
+// CreateApp 内部的 observability.Initialize() 在 OTEL_ENABLE=true 时会把全局 provider
+// 换成真 OTLP 的，测试的 exporter 就接不到了。所以先关着 OTEL 建 app，再开 OTEL 重新 Init 扩展。
+func newExt(t *testing.T) *redisv9ext.RedisExt {
+	t.Helper()
+	t.Setenv("OTEL_ENABLE", "false")
+	ext := &redisv9ext.RedisExt{NS: "redis_"}
+	app, err := gobay.CreateApp("../../../testdata/", "redispool", map[gobay.Key]gobay.Extension{"redis": ext})
+	if err != nil {
+		t.Fatalf("CreateApp failed: %v", err)
+	}
+	_ = ext.Close()
+	t.Setenv("OTEL_ENABLE", "true")
+	if err := ext.Init(app); err != nil {
+		t.Fatalf("re-Init with OTEL_ENABLE=true failed: %v", err)
+	}
+	t.Cleanup(func() { _ = ext.Close() })
+	return ext
+}
+
+var parentSpanID = trace.SpanID{0x00, 0xf0, 0x67, 0xaa, 0x0b, 0xa9, 0x02, 0xb7}
+
+func sampledParent() context.Context {
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    trace.TraceID{0x4b, 0xf9, 0x2f, 0x35, 0x77, 0xb3, 0x4d, 0xa6, 0xa3, 0xce, 0x92, 0x9d, 0x0e, 0x0e, 0x47, 0x36},
+		SpanID:     parentSpanID,
+		TraceFlags: trace.FlagsSampled,
+		Remote:     true,
+	})
+	return trace.ContextWithRemoteSpanContext(context.Background(), sc)
+}
+
+// 探针 / 无拦截器的 gRPC handler 传进来的 ctx 没有 span：不能再产出孤儿 span
+func TestOtel_CommandWithoutParentExportsNoSpan(t *testing.T) {
+	exp := otelRecorder(t)
+	ext := newExt(t)
+	exp.Reset()
+
+	_, _ = ext.Client().Get(context.Background(), "gobay-otel-orphan-test").Result()
+
+	if spans := exp.GetSpans(); len(spans) != 0 {
+		names := make([]string, 0, len(spans))
+		for _, s := range spans {
+			names = append(names, s.Name)
+		}
+		t.Fatalf("exported %d orphan spans %v, want 0", len(spans), names)
+	}
+}
+
+// 有已采样父级时照常产出，且挂在父级下
+func TestOtel_CommandUnderSampledParentExportsChildSpan(t *testing.T) {
+	exp := otelRecorder(t)
+	ext := newExt(t)
+	exp.Reset()
+
+	_, _ = ext.Client().Get(sampledParent(), "gobay-otel-child-test").Result()
+
+	spans := exp.GetSpans()
+	if len(spans) == 0 {
+		t.Fatal("exported 0 spans, want the redis get span")
+	}
+	var sawGet bool
+	for _, s := range spans {
+		if s.Parent.SpanID() != parentSpanID {
+			t.Errorf("span %q parent = %s, want %s", s.Name, s.Parent.SpanID(), parentSpanID)
+		}
+		if s.Name == "get" {
+			sawGet = true
+		}
+	}
+	if !sawGet {
+		t.Error("no span named \"get\" exported")
+	}
+}

--- a/observability/childonly.go
+++ b/observability/childonly.go
@@ -1,0 +1,47 @@
+package observability
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/embedded"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+// ChildOnlyTracerProvider 返回一个只在 ctx 里已有「有效且已采样」的父级时才真正开 span 的
+// TracerProvider；ctx 里没有父级（k8s 探针、后台 goroutine、没装 traceparent 提取拦截器的
+// gRPC handler）时返回 non-recording span：不记录、不发送。
+//
+// 语义与 entext 的 otelsql SpanFilter、observability/redisotelv6 一致。给 go-redis v9 官方
+// redisotel 这类没有 SpanFilter 的插桩用：它把根 span 交给全局 provider，而全局 provider 的
+// 默认采样器 ParentBased(AlwaysSample) 会把根 span 100% 记录并发送——完全绕过 istio 的头采样，
+// 每条 Redis 命令都变成一条独立的孤儿 trace。
+//
+// 底层 tracer 在每次 Start 时从全局 provider 取，所以扩展 Init 早于 otel.SetTracerProvider
+// 也不会拿到过期的 provider。
+func ChildOnlyTracerProvider() trace.TracerProvider {
+	return childOnlyTracerProvider{}
+}
+
+type childOnlyTracerProvider struct {
+	embedded.TracerProvider
+}
+
+func (childOnlyTracerProvider) Tracer(name string, opts ...trace.TracerOption) trace.Tracer {
+	return childOnlyTracer{name: name, opts: opts}
+}
+
+type childOnlyTracer struct {
+	embedded.Tracer
+	name string
+	opts []trace.TracerOption
+}
+
+func (t childOnlyTracer) Start(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	sc := trace.SpanContextFromContext(ctx)
+	if !sc.IsValid() || !sc.IsSampled() {
+		return ctx, noop.Span{}
+	}
+	return otel.GetTracerProvider().Tracer(t.name, t.opts...).Start(ctx, spanName, opts...)
+}

--- a/observability/childonly_test.go
+++ b/observability/childonly_test.go
@@ -1,0 +1,106 @@
+package observability
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// 与线上 initOtel 一致：不设 Sampler，走 SDK 默认的 ParentBased(AlwaysSample)。
+// 根 span 在这个 provider 下是会被记录的，这正是孤儿 span 的来源。
+func recorder(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prev)
+		_ = tp.Shutdown(context.Background())
+	})
+	return exp
+}
+
+var (
+	parentTraceID = trace.TraceID{0x4b, 0xf9, 0x2f, 0x35, 0x77, 0xb3, 0x4d, 0xa6, 0xa3, 0xce, 0x92, 0x9d, 0x0e, 0x0e, 0x47, 0x36}
+	parentSpanID  = trace.SpanID{0x00, 0xf0, 0x67, 0xaa, 0x0b, 0xa9, 0x02, 0xb7}
+)
+
+// 模拟 envoy 通过 traceparent 传进来、已被拦截器 Extract 进 ctx 的远程父级
+func withRemoteParent(sampled bool) context.Context {
+	var flags trace.TraceFlags
+	if sampled {
+		flags = trace.FlagsSampled
+	}
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    parentTraceID,
+		SpanID:     parentSpanID,
+		TraceFlags: flags,
+		Remote:     true,
+	})
+	return trace.ContextWithRemoteSpanContext(context.Background(), sc)
+}
+
+// 对照组：证明差异来自 ChildOnlyTracerProvider 而不是测试环境——
+// 直接用全局 provider 开根 span 是会被导出的。
+func TestGlobalProvider_RecordsRootSpan(t *testing.T) {
+	exp := recorder(t)
+	_, span := otel.GetTracerProvider().Tracer("t").Start(context.Background(), "get")
+	span.End()
+	if got := len(exp.GetSpans()); got != 1 {
+		t.Fatalf("global provider exported %d spans, want 1", got)
+	}
+}
+
+func TestChildOnlyTracerProvider_RootSpanNotRecorded(t *testing.T) {
+	exp := recorder(t)
+	_, span := ChildOnlyTracerProvider().Tracer("t").Start(context.Background(), "get")
+	if span.IsRecording() {
+		t.Error("root span IsRecording() = true, want false")
+	}
+	span.End()
+	if got := len(exp.GetSpans()); got != 0 {
+		t.Fatalf("exported %d spans, want 0 (root span must be dropped)", got)
+	}
+}
+
+func TestChildOnlyTracerProvider_ChildOfSampledRemoteParentRecorded(t *testing.T) {
+	exp := recorder(t)
+	_, span := ChildOnlyTracerProvider().Tracer("t").Start(withRemoteParent(true), "get")
+	span.End()
+	spans := exp.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("exported %d spans, want 1", len(spans))
+	}
+	if spans[0].Parent.SpanID() != parentSpanID {
+		t.Errorf("parent span id = %s, want %s", spans[0].Parent.SpanID(), parentSpanID)
+	}
+	if spans[0].SpanContext.TraceID() != parentTraceID {
+		t.Errorf("trace id = %s, want %s", spans[0].SpanContext.TraceID(), parentTraceID)
+	}
+}
+
+func TestChildOnlyTracerProvider_ChildOfUnsampledParentNotRecorded(t *testing.T) {
+	exp := recorder(t)
+	_, span := ChildOnlyTracerProvider().Tracer("t").Start(withRemoteParent(false), "get")
+	span.End()
+	if got := len(exp.GetSpans()); got != 0 {
+		t.Fatalf("exported %d spans, want 0 (parent not sampled)", got)
+	}
+}
+
+// 用的是调用时的全局 provider，而不是构造时快照——服务启动顺序里
+// 扩展 Init 可能早于 SetTracerProvider。
+func TestChildOnlyTracerProvider_FollowsGlobalProviderSetLater(t *testing.T) {
+	tp := ChildOnlyTracerProvider()
+	exp := recorder(t) // 在拿到 provider 之后才替换全局
+	_, span := tp.Tracer("t").Start(withRemoteParent(true), "get")
+	span.End()
+	if got := len(exp.GetSpans()); got != 1 {
+		t.Fatalf("exported %d spans, want 1", got)
+	}
+}


### PR DESCRIPTION
> 线上验证：permission / lune（孤儿 7.8 万、6.5 万/天 → 0）、quest（对照，带父级 span 原样保留，一天 5.7 万条）三服务 stag + pro 均已用本 PR 的 head `621b764` 跑过，21 个 pod 0 重启无报错。

## 问题

go-redis v9 官方 `redisotel` 没有 SpanFilter：ctx 没有父级时它照样开根 span，而全局 provider 的默认采样器 `ParentBased(AlwaysSample)` 会把根 span 100% 记录并发送，完全绕过 istio 的头采样。k8s 探针里的 `CheckHealth`（ping+set+get+del）和没提取 traceparent 的 gRPC handler 里的每条 Redis 命令都变成一条独立的孤儿 trace。线上 permission / lune 各约 5~8 万条/天，其中约 2/3 来自探针。

## 改动（生产代码 53 行）

- 新增 `observability.ChildOnlyTracerProvider()`：ctx 里没有有效且已采样的父级 → 返回 non-recording span；有父级 → 转交全局 provider（每次 Start 时取，不受扩展 Init 早于 `otel.SetTracerProvider` 的顺序影响）。语义与 entext 的 otelsql SpanFilter、`redisotelv6` 一致
- `redisext/v9`、`cachext` redis v9 backend 的 `redisotel.InstrumentTracing` 改用它，其余不动

**不动全局 sampler**——那会把 beat / cron 里合法的根 span 也砍掉。

## 验证

- 新增 9 个用例，全部先 RED 后 GREEN：
  - `observability`：根 span 不记录 / 已采样远程父级下记录且 parent 正确 / 未采样父级不记录 / provider 后设也生效；另有一条对照用例证明全局 provider 本身会记录根 span，差异确实来自这里
  - `redisext/v9`、`cachext/backend/redis/v9`：真实 Redis 上无父级命令 0 条导出、有父级命令全挂在父级下（`CheckHealth` 用探针 ctx 也是 0 条）
- `go test ./...`（排除本地没起 RabbitMQ 的 busext）除 `extensions/entext.TestEnt` 外全绿——该用例在干净的 `origin/master` 上同样 nil-deref 崩（`ext_test.go:49`，本地 MySQL 环境），与本 PR 无关
- `go vet ./...` 干净

## 影响面

升级后，用 v9 redisext / cachext 的服务：无父级的 Redis 命令不再产 span（孤儿归零，探针不再产 span）；有父级的照常。其他扩展、v6 路径、全局 provider 均不变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wx43oBwasHG6vvtL3RDXxq
